### PR TITLE
Allow users to see a list of donors

### DIFF
--- a/app/controllers/donors_controller.rb
+++ b/app/controllers/donors_controller.rb
@@ -4,6 +4,11 @@ class DonorsController < ApplicationController
     @donor = find_donor(params[:id])
   end
 
+  # GET /donors
+  def index
+    @donors = Donor.all
+  end
+
   private
 
   def find_donor(id)

--- a/app/models/donor.rb
+++ b/app/models/donor.rb
@@ -2,4 +2,8 @@ class Donor < ActiveRecord::Base
   has_many :donations, inverse_of: :donor
 
   validates :identification, presence: true
+
+  def total_donations
+    donations.sum(:amount).truncate
+  end
 end

--- a/app/views/donors/index.html.erb
+++ b/app/views/donors/index.html.erb
@@ -1,0 +1,20 @@
+<div class="table-responsive">
+  <table class="table">
+    <thead class="thead-default">
+      <tr>
+        <th>Name</th>
+        <th>NRIC/UEM</th>
+        <th>Total Donation</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @donors.each do |donor| %>
+        <tr>
+          <td><%= donor.name %></td>
+          <td><%= donor.identification %></td>
+          <td>$<%= number_with_delimiter(donor.total_donations, delimiter: ",") %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -1,6 +1,9 @@
 <nav class="navbar navbar-light navbar-static-top">
   <div class="collapse navbar-toggleable-xs" id="exCollapsingNavbar2">
     <ul class="nav navbar-nav">
+      <li class="nav-item">
+        <%= link_to 'Donors', donors_path %>
+      </li>
       <li class="nav-item pull-sm-right">
         <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#myModal">
           <i class="fa fa-plus" aria-hidden="true"></i>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,4 @@
 Rails.application.routes.draw do
   resources :donations, only: :create
-  resources :donors, only: :show
+  resources :donors, only: [:show, :index]
 end

--- a/spec/factories/donors.rb
+++ b/spec/factories/donors.rb
@@ -5,5 +5,11 @@ FactoryGirl.define do
     trait :invalid do
       identification nil
     end
+
+    factory :donor_with_donations do
+      after(:create) do |donor, _|
+        create_list(:donation, 2, donor: donor)
+      end
+    end
   end
 end

--- a/spec/models/donor_spec.rb
+++ b/spec/models/donor_spec.rb
@@ -4,4 +4,12 @@ RSpec.describe Donor, type: :model do
   it { is_expected.to have_many(:donations).inverse_of(:donor) }
 
   it { is_expected.to validate_presence_of(:identification) }
+
+  describe "#total_donations" do
+    let(:donor) { FactoryGirl.create(:donor_with_donations) }
+
+    it "shows total amount donated" do
+      expect(donor.total_donations).to eq(200)
+    end
+  end
 end


### PR DESCRIPTION
This change creates an `index` page for Donors with a table showing Donor's name, identification and total amount donated.

The `index` page can viewed by pressing "Donors" link in the navigation bar.

See screenshots below:

![screencapture-localhost-3000-donors-1475228792414](https://cloud.githubusercontent.com/assets/19661205/18987782/ea48fd16-8735-11e6-9526-f859792db800.png)

---

**Before submitting, check that:**

 - [x] You have written good* commit messages.
 - [x] You have ensured that RuboCop is passing.
 - [x] Your PR relates to one subject, with a clear title and
       description using complete, grammatically correct sentences.

---

If your change contains views, ensure that:

 - [x] You have included a screenshot of the new view.

---

*If you do not know what makes a good commit message, or why it
is important, please refer to these resources: [1][1], [2][2], [3][3].

[1]: https://robots.thoughtbot.com/5-useful-tips-for-a-better-commit-message
[2]: http://chris.beams.io/posts/git-commit/
[3]: https://github.com/blog/1943-how-to-write-the-perfect-pull-request

