### PR TITLE
Allow Users to create events

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,0 +1,27 @@
+class EventsController < ApplicationController
+  before_action :prepare_modal_event
+
+  def index
+    @events = Event.all
+  end
+
+  def create
+    @event = Event.new(event_params)
+
+    if @event.save
+      redirect_to events_path, notice: "Event was successfully created."
+    else
+      redirect_to events_path, alert: "Failed to save event."
+    end
+  end
+
+  private
+
+  def prepare_modal_event
+    @modal_event = Event.new
+  end
+
+  def event_params
+    params.require(:event).permit(:name, :start_on, :end_on)
+  end
+end

--- a/app/models/donation.rb
+++ b/app/models/donation.rb
@@ -1,6 +1,7 @@
 class Donation < ActiveRecord::Base
   belongs_to :donor, inverse_of: :donations
   belongs_to :cause, inverse_of: :donations
+  belongs_to :event, inverse_of: :donations
 
   validates :donor, presence: true
   validates :amount, presence: true, numericality: { greater_than: 0 }

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,0 +1,7 @@
+class Event < ActiveRecord::Base
+  has_many :donations, inverse_of: :event
+
+  validates :start_on, presence: true
+  validates :end_on, presence: true
+  validates :name, presence: true
+end

--- a/app/views/donations/_new.html.erb
+++ b/app/views/donations/_new.html.erb
@@ -1,4 +1,4 @@
-<div class="modal fade" id="myModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
+<div class="modal fade" id="donationModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
   <div class="modal-dialog modal-sm" role="document">
     <div class="modal-content">
       <div class="modal-body">

--- a/app/views/events/_new.html.erb
+++ b/app/views/events/_new.html.erb
@@ -1,0 +1,33 @@
+<div class="modal fade" id="eventModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
+  <div class="modal-dialog modal-sm" role="document">
+    <div class="modal-content">
+      <div class="modal-body">
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+        <h4 class="modal-title">Event Details</h4>
+        <%= form_for(@modal_event) do |f| %>
+            <div class="form-group">
+              <%= f.label :name, "Event Name", class: "control-label" %>
+              <%= f.text_field :name, class: "form-control" %>
+            </div>
+
+            <div class="form-group">
+              <%= f.label :start_on, "Start date", class: "control-label" %>
+              <%= f.date_field :start_on, class: "form-control" %>
+            </div>
+
+            <div class="form-group">
+              <%= f.label :end_on, "End date", class: "control-label" %>
+              <%= f.date_field :end_on, class: "form-control" %>
+            </div>
+
+            <div class="actions">
+              <%= f.submit class: "btn btn-primary form-control" %>
+            </div>
+
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -1,0 +1,9 @@
+<%= render "events/new" %>
+<div class="row">
+  <div class="col-xs-12 col-sm-4 offset-sm-8 eventsButton">
+	<button type="button" class="btn btn-primary pull-right" data-toggle="modal" data-target="#eventModal">
+	  <i class="fa fa-plus" aria-hidden="true"></i>
+	  Add New Event
+	</button>
+  </div>
+</div>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -5,7 +5,7 @@
         <%= link_to 'Donors', donors_path %>
       </li>
       <li class="nav-item pull-sm-right">
-        <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#myModal">
+        <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#donationModal">
           <i class="fa fa-plus" aria-hidden="true"></i>
           New donation
         </button>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
   resources :donations, only: :create
   resources :donors, only: [:show, :index, :update, :edit]
+  resources :events, only: [:index, :create]
 end

--- a/db/migrate/20161002134530_create_events.rb
+++ b/db/migrate/20161002134530_create_events.rb
@@ -1,0 +1,11 @@
+class CreateEvents < ActiveRecord::Migration
+  def change
+    create_table :events do |t|
+      t.string :name, null: false
+      t.date :start_on, null: false
+      t.date :end_on, null: false
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160926083857) do
+ActiveRecord::Schema.define(version: 20161002134530) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -42,6 +42,14 @@ ActiveRecord::Schema.define(version: 20160926083857) do
     t.string   "email_address"
     t.datetime "created_at",     null: false
     t.datetime "updated_at",     null: false
+  end
+
+  create_table "events", force: :cascade do |t|
+    t.string   "name",       null: false
+    t.date     "start_on",   null: false
+    t.date     "end_on",     null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   add_foreign_key "donations", "causes"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,5 +1,6 @@
 require_relative "seeds/donors"
 require_relative "seeds/causes"
+require_relative "seeds/events"
 
 require_relative "seeds/donations"
 

--- a/db/seeds/events.rb
+++ b/db/seeds/events.rb
@@ -1,0 +1,16 @@
+puts "Seeding Events ..."
+
+events = [
+    name: "Past Event",
+    start_on: 1.year.ago,
+    end_on: 1.year.ago + 1.day
+  ],
+  [
+    name: "Future Event",
+    start_on: 1.year.from_now,
+    end_on: 1.year.from_now + 1.day
+  ]
+
+unless Event.any?
+  Event.create!(events)
+end

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.describe EventsController, type: :controller do
+  let(:event) { instance_double(Event) }
+
+  before do
+    allow(event).to receive(:save) { save_result }
+  end
+
+  describe "POST #create" do
+    before do
+      post :create, event: FactoryGirl.attributes_for(:event)
+    end
+
+    context "when event is saved successfully" do
+      let(:save_result) { true }
+
+      it { expect(response).to have_http_status(:found) }
+    end
+
+    context "when event is not saved successfully" do
+      let(:save_result) { false }
+
+      it { expect(response).to have_http_status(:found) }
+    end
+  end
+end

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -1,0 +1,9 @@
+FactoryGirl.define do
+  factory :event do
+    name "Test Event"
+
+    trait :invalid do
+      name nil
+    end
+  end
+end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -1,0 +1,7 @@
+require "rails_helper"
+
+RSpec.describe Event, type: :model do
+  it { is_expected.to validate_presence_of(:start_on) }
+  it { is_expected.to validate_presence_of(:end_on) }
+  it { is_expected.to validate_presence_of(:name) }
+end


### PR DESCRIPTION
This change allows users to enter new events through a modal.

Note! This change has migrations. Please run: rake db:drop db:create db:migrate db:seed after pulling the changes.

See screenshots below:

![screencapture-localhost-3000-events-1475479240668](https://cloud.githubusercontent.com/assets/19661205/19029967/22ddfe30-897d-11e6-9640-55452c2d33b4.png)

**Before submitting, check that:**

 - [x] You have added (passing) tests for your code.
 - [x] You have written good* commit messages.
 - [ ] You have squashed relevant commits together.
 - [x] You have ensured that RuboCop is passing.
 - [x] Your PR relates to one subject, with a clear title and
       description using complete, grammatically correct sentences.

---

If your change contains models, ensure that:

 - [x] You have added database seeds for the model.
 - [x] You have added working factories for the model.
 - [x] Your validations have corresponding database constraints.

---

If your change contains views, ensure that:

 - [x] You have included a screenshot of the new view.

---

*If you do not know what makes a good commit message, or why it
is important, please refer to these resources: [1][1], [2][2], [3][3].

[1]: https://robots.thoughtbot.com/5-useful-tips-for-a-better-commit-message
[2]: http://chris.beams.io/posts/git-commit/
[3]: https://github.com/blog/1943-how-to-write-the-perfect-pull-request

