### PR TITLE
Add list of donations to donor page

### DIFF
--- a/app/views/donors/show.html.erb
+++ b/app/views/donors/show.html.erb
@@ -7,3 +7,31 @@
 <div id="show_partial">
   <%= render "show" %>
 </div>
+
+<div>
+  <h2>Total Amount Donated</h2>
+  <h1>$<%= number_with_delimiter(@donor.total_donations, delimiter: ",") %></h1>
+  <h5>Donor since <%= @donor.created_at.strftime("%d %b %Y") %> (<%= time_ago_in_words(@donor.created_at) %>)</h5>
+</div>
+
+<div class="table-responsive">
+  <table class="table">
+    <thead class="thead-default">
+      <tr>
+        <th>Date</th>
+        <th>Amount</th>
+        <th>Cause</th>
+        <th>Event</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @donor.donations.each do |donation| %>
+      <tr>
+        <td><%= donation.created_at.to_formatted_s(:short) %> (<%= donation.created_at.strftime("%Y") %>)</td>
+        <td>$<%= donation.amount.to_i %></td>
+        <td><%= donation.cause.name %></td>
+      </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>


### PR DESCRIPTION
This change allows users to view a list of donations on the donor page.

The screen shots of the donor page are below.

Screenshot of donor page:
![screen shot 2016-10-08 at 2 18 35 pm](https://cloud.githubusercontent.com/assets/16523290/19210905/4f9ca942-8d62-11e6-8846-0be10a7fd6ac.png)

Screenshot when edit form is clicked:
![screen shot 2016-10-08 at 2 18 47 pm](https://cloud.githubusercontent.com/assets/16523290/19210906/5764b624-8d62-11e6-8c52-41c3a1e8f25a.png)


---

**Before submitting, check that:**

 - [ ] You have added (passing) tests for your code.
 - [x] You have written good* commit messages.
 - [x] You have squashed relevant commits together.
 - [x] You have ensured that RuboCop is passing.
 - [x] Your PR relates to one subject, with a clear title and
       description using complete, grammatically correct sentences.

---

If your change contains views, ensure that:

 - [x] You have included a screenshot of the new view.

---

*If you do not know what makes a good commit message, or why it
is important, please refer to these resources: [1][1], [2][2], [3][3].

[1]: https://robots.thoughtbot.com/5-useful-tips-for-a-better-commit-message
[2]: http://chris.beams.io/posts/git-commit/
[3]: https://github.com/blog/1943-how-to-write-the-perfect-pull-request


