### PR TITLE
Get Bootstrap 4 working on Heroku

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gem "rails", "~> 4.2.7.1"
 gem "pg", "~> 0.15"
 
 gem "sass-rails", "~> 5.0"
+gem "rails-assets-tether", "~> 1.1.0"
 gem "bootstrap", "~> 4.0.0.alpha4"
 gem "font-awesome-rails"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -106,6 +106,7 @@ GEM
       bundler (>= 1.3.0, < 2.0)
       railties (= 4.2.7.1)
       sprockets-rails
+    rails-assets-tether (1.1.1)
     rails-deprecated_sanitizer (1.0.3)
       activesupport (>= 4.2.0.alpha)
     rails-dom-testing (1.0.7)
@@ -203,6 +204,7 @@ DEPENDENCIES
   jquery-rails
   pg (~> 0.15)
   rails (~> 4.2.7.1)
+  rails-assets-tether (~> 1.1.0)
   rails_12factor
   rspec-rails
   rubocop

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -14,5 +14,6 @@
 
 //= require jquery_ujs
 //= require turbolinks
+//= require tether
 //= require bootstrap-sprockets
 //= require_tree .


### PR DESCRIPTION
According to the Bootstrap Gem [documentation](https://github.com/twbs/bootstrap-rubygem#a-ruby-on-rails), tooltips depend on another library called Tether. Adding this will hopefully get Bootstrap working on Heroku.

---

**Before submitting, check that:**

 - [X] You have written good* commit messages.
 - [X] You have squashed relevant commits together.
 - [X] You have ensured that RuboCop is passing.
 - [X] Your PR relates to one subject, with a clear title and
       description using complete, grammatically correct sentences.

---

*If you do not know what makes a good commit message, or why it
is important, please refer to these resources: [1][1], [2][2], [3][3].

[1]: https://robots.thoughtbot.com/5-useful-tips-for-a-better-commit-message
[2]: http://chris.beams.io/posts/git-commit/
[3]: https://github.com/blog/1943-how-to-write-the-perfect-pull-request