### PR TITLE
Change references of UEM to UEN for donors and donations

### DIFF
--- a/app/views/donations/_new.html.erb
+++ b/app/views/donations/_new.html.erb
@@ -8,7 +8,7 @@
 
         <%= form_for(@modal_donation) do |f| %>
             <div class="form-group">
-              <label for="donorDocs" class="form-control-label">Donor NRIC/UEM Number</label>
+              <label for="donorDocs" class="form-control-label">Donor NRIC/UEN Number</label>
               <input type="text" class="form-control" id="donorDocs">
             </div>
 

--- a/app/views/donors/_edit.html.erb
+++ b/app/views/donors/_edit.html.erb
@@ -14,7 +14,7 @@
     </div>
 
     <div class="form-group">
-      <label for="donorDocs" class="control-label">NRIC/UEM</label>
+      <label for="donorDocs" class="control-label">NRIC/UEN</label>
       <%= f.text_field :identification, disabled: true, class: "form-control" %>
     </div>
   </div>

--- a/app/views/donors/_show.html.erb
+++ b/app/views/donors/_show.html.erb
@@ -3,7 +3,7 @@
     <p>Name</p>
     <p><%= @donor.name %></p>
 
-    <p>NRIC/UEM</p>
+    <p>NRIC/UEN</p>
     <p><%= @donor.identification %></p>
 
   </div>

--- a/app/views/donors/index.html.erb
+++ b/app/views/donors/index.html.erb
@@ -3,7 +3,7 @@
     <thead class="thead-default">
       <tr>
         <th>Name</th>
-        <th>NRIC/UEM</th>
+        <th>NRIC/UEN</th>
         <th>Total Donation</th>
       </tr>
     </thead>


### PR DESCRIPTION
[Fix #19] This change fixes the typo in `donor` and `donation` views from UEM to UEN. In our database the field is called "identification", no change needed there.

---
 - [x] You have written good* commit messages.
 - [x] You have squashed relevant commits together.
 - [x] You have ensured that RuboCop is passing.
 - [x] Your PR relates to one subject, with a clear title and
       description using complete, grammatically correct sentences.

If you do not know what makes a good commit message, or why it
is important, please refer to these resources: [1][1], [2][2], [3][3].

[1]: https://robots.thoughtbot.com/5-useful-tips-for-a-better-commit-message
[2]: http://chris.beams.io/posts/git-commit/
[3]: https://github.com/blog/1943-how-to-write-the-perfect-pull-request


