### PR TITLE
Allow user to edit donations on donor page

### DIFF
--- a/app/controllers/donations_controller.rb
+++ b/app/controllers/donations_controller.rb
@@ -10,13 +10,27 @@ class DonationsController < ApplicationController
     end
   end
 
+  def update
+    @donation = find_donation(params[:id])
+    if @donation.update(donation_params)
+      redirect_to donor_path(@donation.donor), notice: "Donation was successfully updated."
+    else
+      redirect_to donor_path(@donation.donor), error: "Failed to update donation."
+    end
+  end
+
+  def edit
+    @donation = find_donation(params[:id])
+    render :edit
+  end
+
   private
 
-  def find_donation
-    Donation.find(params[:id])
+  def find_donation(id)
+    Donation.find(id)
   end
 
   def donation_params
-    params.require(:donation).permit(:amount)
+    params.require(:donation).permit(:amount, :cause_id, :event_id)
   end
 end

--- a/app/models/cause.rb
+++ b/app/models/cause.rb
@@ -2,5 +2,5 @@ class Cause < ActiveRecord::Base
   has_many :donations, inverse_of: :cause
 
   validates :shortcode, presence: true
-  validates :name, presence: true
+  validates :name, presence: true, uniqueness: true
 end

--- a/app/views/donations/_edit.html.erb
+++ b/app/views/donations/_edit.html.erb
@@ -1,0 +1,34 @@
+<div class="modal fade" id="donationeditModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
+  <div class="modal-dialog modal-sm" role="document">
+    <div class="modal-content">
+      <div class="modal-body">
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+
+        <% @donor.donations.each do |donation| %>
+          <%= form_for(donation) do |f| %>
+          <div class="form-group">
+            <%= f.label :amount, class: "control-label" %>
+            <%= f.text_field :amount, class: "form-control" %>
+          </div>
+
+          <div class="form-group">
+            <label for="causeOrEvent" class="form-control-label">Cause:</label>
+            <%= f.select :cause_id, options_for_select(Cause.pluck(:name, :id)), {}, class:"form-control" %>
+          </div>
+
+          <div class="form-group">
+            <label for="causeOrEvent" class="form-control-label">Event:</label>
+            <%= f.select :event_id, options_for_select(Event.pluck(:name, :id)), {}, class:"form-control" %>
+          </div>
+
+          <div class="actions">
+            <%= f.submit "Save changes", class: "btn btn-primary form-control" %>
+          </div>
+          <% end %>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/donations/_new.html.erb
+++ b/app/views/donations/_new.html.erb
@@ -12,19 +12,19 @@
               <input type="text" class="form-control" id="donorDocs">
             </div>
 
-            <div class="form-group">
-              <%= f.label :amount, class: "control-label" %>
-              <%= f.text_field :amount, class: "form-control" %>
-            </div>
+        <div class="form-group">
+          <%= f.label :amount, class: "control-label" %>
+          <%= f.text_field :amount, class: "form-control" %>
+        </div>
 
-            <div class="form-group">
-              <label for="causeOrEvent" class="form-control-label">Cause or Event:</label>
-              <input type="text" class="form-control" id="causeOrEvent">
-            </div>
+        <div class="form-group">
+          <label for="causeOrEvent" class="form-control-label">Cause or Event:</label>
+          <input type="text" class="form-control" id="causeOrEvent">
+        </div>
 
-            <div class="actions">
-              <%= f.submit class: "btn btn-primary form-control" %>
-            </div>
+        <div class="actions">
+          <%= f.submit class: "btn btn-primary form-control" %>
+        </div>
 
         <% end %>
       </div>

--- a/app/views/donors/show.html.erb
+++ b/app/views/donors/show.html.erb
@@ -18,10 +18,11 @@
   <table class="table">
     <thead class="thead-default">
       <tr>
-        <th>Date</th>
+        <th>Date Created</th>
         <th>Amount</th>
         <th>Cause</th>
         <th>Event</th>
+        <th></th>
       </tr>
     </thead>
     <tbody>
@@ -30,8 +31,17 @@
         <td><%= donation.created_at.to_formatted_s(:short) %> (<%= donation.created_at.strftime("%Y") %>)</td>
         <td>$<%= donation.amount.to_i %></td>
         <td><%= donation.cause.name %></td>
+        <td><% if donation.event %><%= donation.event.name %><% end %></td>
+        <td><%= link_to edit_donation_path, data: {toggle: "modal", target: "#donationeditModal"} do %>
+          <i class="fa fa-pencil fa-lg"></i>
+          <% end %>
+        </td>
       </tr>
       <% end %>
     </tbody>
   </table>
+</div>
+
+<div>
+  <%= render "donations/edit" %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  resources :donations, only: :create
+  resources :donations, only: [:create, :update, :edit]
   resources :donors, only: [:show, :index, :update, :edit]
   resources :events, only: [:index, :create]
 end

--- a/db/migrate/20161009153659_add_event_to_donations.rb
+++ b/db/migrate/20161009153659_add_event_to_donations.rb
@@ -1,0 +1,5 @@
+class AddEventToDonations < ActiveRecord::Migration
+  def change
+    add_reference :donations, :event, index: true, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161002134530) do
+ActiveRecord::Schema.define(version: 20161009153659) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -29,10 +29,12 @@ ActiveRecord::Schema.define(version: 20161002134530) do
     t.decimal  "amount",     null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer  "event_id"
   end
 
   add_index "donations", ["cause_id"], name: "index_donations_on_cause_id", using: :btree
   add_index "donations", ["donor_id"], name: "index_donations_on_donor_id", using: :btree
+  add_index "donations", ["event_id"], name: "index_donations_on_event_id", using: :btree
 
   create_table "donors", force: :cascade do |t|
     t.string   "identification", null: false
@@ -66,4 +68,5 @@ ActiveRecord::Schema.define(version: 20161002134530) do
 
   add_foreign_key "donations", "causes"
   add_foreign_key "donations", "donors"
+  add_foreign_key "donations", "events"
 end

--- a/db/seeds/donations.rb
+++ b/db/seeds/donations.rb
@@ -4,6 +4,7 @@ unless Donation.any?
   Donation.create!(
     donor: Donor.first,
     cause: Cause.first,
+    event: Event.first,
     amount: 100
   )
 end


### PR DESCRIPTION
This change allows user to edit donations on the donor page. A user can edit both cause and event when editing a donation.

Screenshot of donor page:
![screen shot 2016-10-11 at 2 29 40 am](https://cloud.githubusercontent.com/assets/16523290/19246788/ab1082ea-8f5a-11e6-954d-31829cfc6d51.png)

Screenshot of donation edit form:
![screen shot 2016-10-10 at 11 09 20 pm](https://cloud.githubusercontent.com/assets/16523290/19240925/1e23db68-8f3f-11e6-99ef-7b6e438bf54b.png)

**Before submitting, check that:**

 - [ ] You have added (passing) tests for your code.
 - [x] You have written good* commit messages.
 - [x] You have squashed relevant commits together.
 - [x] You have ensured that RuboCop is passing.
 - [x] Your PR relates to one subject, with a clear title and
       description using complete, grammatically correct sentences.

---

If your change contains models, ensure that:

 - [ ] You have included an updated screen shot of the ERD.
 - [ ] You have added database seeds for the model.
 - [ ] You have added working factories for the model.
 - [ ] Your validations have corresponding database constraints.

---

If your change contains views, ensure that:

 - [x] You have included a screenshot of the new view.

---

*If you do not know what makes a good commit message, or why it
is important, please refer to these resources: [1][1], [2][2], [3][3].

[1]: https://robots.thoughtbot.com/5-useful-tips-for-a-better-commit-message
[2]: http://chris.beams.io/posts/git-commit/
[3]: https://github.com/blog/1943-how-to-write-the-perfect-pull-request

