### PR TITLE
[Fix #23] Show an error when creating an event with an end date after a start date

### DIFF
--- a/app/controllers/donations_controller.rb
+++ b/app/controllers/donations_controller.rb
@@ -6,7 +6,7 @@ class DonationsController < ApplicationController
     if @donation.save
       redirect_to donations_path, notice: "Donation was successfully created."
     else
-      redirect_to donations_path, error: "Failed to save donation."
+      redirect_to donations_path, error: @event.errors.full_messages.to_sentence
     end
   end
 

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -19,7 +19,7 @@ class EventsController < ApplicationController
     if @event.save
       redirect_to events_path, notice: "Event was successfully created."
     else
-      redirect_to events_path, alert: "Failed to save event."
+      redirect_to events_path, alert: @event.errors.full_messages.to_sentence
     end
   end
 

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -6,6 +6,13 @@ class Event < ActiveRecord::Base
   validates :start_on, presence: true
   validates :end_on, presence: true
   validates :name, presence: true
+  validate :start_before_end
+
+  def start_before_end
+    if end_on && start_on
+      errors.add(:base, "End Date cannot be before Start Date") if end_on < start_on
+    end
+  end
 
   scope :search, -> (keyword) { where("name ILIKE ?", "%#{keyword}%") }
 

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -19,4 +19,10 @@ RSpec.describe Event, type: :model do
 
     it { expect(event.total_donations).to eq(200) }
   end
+
+  describe "#start_before_end" do
+    let(:event) { build(:event, name: "Test dates input", start_on: 1.year.ago + 1.day, end_on: 1.year.ago) }
+
+    it { expect(event).to_not be_valid }
+  end
 end


### PR DESCRIPTION
This change checks that when creating an event `end_on` date cannot be before a `start_on` date.

---

**Before submitting, check that:**

 - [x] You have added (passing) tests for your code.
 - [x] You have written good* commit messages.
 - [x] You have squashed relevant commits together.
 - [x] You have ensured that RuboCop is passing.
 - [x] Your PR relates to one subject, with a clear title and
       description using complete, grammatically correct sentences.

---

*If you do not know what makes a good commit message, or why it
is important, please refer to these resources: [1][1], [2][2], [3][3].

[1]: https://robots.thoughtbot.com/5-useful-tips-for-a-better-commit-message
[2]: http://chris.beams.io/posts/git-commit/
[3]: https://github.com/blog/1943-how-to-write-the-perfect-pull-request

