### PR TITLE
Allow users to search for a donation by donor name when viewing an event

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -3,6 +3,11 @@ class EventsController < ApplicationController
 
   def show
     @event = find_event(params[:id])
+    @donations = if params[:search]
+                   Donation.search(params[:search])
+                 else
+                   Donation.all
+                 end
   end
 
   def index

--- a/app/models/donation.rb
+++ b/app/models/donation.rb
@@ -5,4 +5,6 @@ class Donation < ActiveRecord::Base
 
   validates :donor, presence: true
   validates :amount, presence: true, numericality: { greater_than: 0 }
+
+  scope :search, -> (keyword) { joins(:donor).where("name ILIKE ?", "%#{keyword}%") }
 end

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -1,25 +1,53 @@
+<%= link_to "< Back to Events' List", events_path %>
 <div class="row">
   <div class="col-xs-12 col-sm-8">
     <h1><%= @event.name %></h1>
   </div>
 </div>
+<div class="card card-inverse card-info text-xs-center">
+  <div class="card-block">
+    <h1>Total amount donated</h1>
+    <h1>$ <%= number_with_delimiter(@event.total_donations, delimiter: ",") %></h1>
+  </div>
+</div>
 <div class="table-responsive">
-  <table class="table">
-    <thead class="thead-default">
-      <tr>
-        <th>Name</th>
-        <th>Date</th>
-        <th>Total Donations</th>
-      </tr>
-    </thead>
-    <tbody>
-      <% @event.donations.each do |donation| %>
+  <%= form_tag @event, method: :get do %>
+    <table class="table">
+      <thead class="thead-default">
         <tr>
-          <td><%= donation.donor.name %></td>
-          <td><%= l donation.created_at.to_date %></td>
-          <td>$<%= number_with_delimiter(donation.amount.round, delimiter: ",") %></td>
+          <td colspan="3">
+            <div class="row">
+              <div class="col-xs-12 col-sm-6 col-md-4 offset-sm-6 offset-md-8">
+                <div class="input-group">
+                      <%= text_field_tag :search, params[:search], placeholder: "Type here...", class: "form-control" %>
+                      <span class="input-group-btn">
+                        <%= submit_tag "Search", name: :nil, class: "btn btn-secondary" %>
+                      </span>
+                </div>
+              </div>
+            </div>
+          </td>
         </tr>
-      <% end %>
-    </tbody>
-  </table>
+        <tr>
+          <th>Name</th>
+          <th>Date</th>
+          <th>Total Donations</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <% if @donations.blank? %>
+            <h4>There is no Donation from a Donor named <%= params[:search] %>.</h4>
+          <% end %>
+        </tr>
+        <% @donations.each do |donation| %>
+          <tr>
+            <td><%= donation.donor.name %></td>
+            <td><%= l donation.created_at.to_date %></td>
+            <td>$<%= number_with_delimiter(donation.amount.round, delimiter: ",") %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  <% end %>
 </div>

--- a/db/seeds/donations.rb
+++ b/db/seeds/donations.rb
@@ -7,13 +7,13 @@ donations = [
   event: Event.first
 ],
 [
-  donor: Donor.first,
+  donor: Donor.second,
   cause: Cause.first,
   amount: 200,
   event: Event.first
 ],
 [
-  donor: Donor.first,
+  donor: Donor.last,
   cause: Cause.first,
   amount: 300,
   event: Event.first

--- a/db/seeds/donors.rb
+++ b/db/seeds/donors.rb
@@ -1,11 +1,27 @@
 puts "Seeding Donors ..."
 
+donors = [
+  identification: "G1234567M",
+  name: "John Smith",
+  address: "123 Street, 0123456 Singapore",
+  phone_number: "12345678",
+  email_address: "john.smith@example.com"
+],
+[
+  identification: "G111111M",
+  name: "Smithie Black",
+  address: "555 Street, 0123456 Singapore",
+  phone_number: "12345678",
+  email_address: "smithie.black@example.com"
+],
+[
+  identification: "G7654321M",
+  name: "Jack Blacksmith",
+  address: "666 Street, 0123456 Singapore",
+  phone_number: "12345678",
+  email_address: "jack.blacksmith@example.com"
+]
+
 unless Donor.any?
-  Donor.create!(
-    identification: "G1234567M",
-    name: "John Smith",
-    address: "123 Street, 0123456 Singapore",
-    phone_number: "12345678",
-    email_address: "john.smith@example.com"
-  )
+  Donor.create!(donors)
 end

--- a/spec/models/donation_spec.rb
+++ b/spec/models/donation_spec.rb
@@ -7,4 +7,18 @@ RSpec.describe Donation, type: :model do
   it { is_expected.to validate_presence_of(:donor) }
   it { is_expected.to validate_presence_of(:amount) }
   it { is_expected.to validate_numericality_of(:amount).is_greater_than(0) }
+
+  describe ".search" do
+    let(:smithie_black) { create(:donor, name: "Smithie Black", identification: "G1234567M") }
+    let(:bob_smith_white) { create(:donor, name: "Bob Smith-White", identification: "G1234567M") }
+    let(:john_smith) { create(:donor, name: "John Smith", identification: "G1234567M") }
+    let(:carl_grey) { create(:donor, name: "Carl Grey", identification: "G1234567M") }
+
+    let(:match_beginning) { create(:donation, amount: 100, donor: smithie_black) }
+    let(:match_middle) { create(:donation, amount: 100, donor: bob_smith_white) }
+    let(:match_end) { create(:donation, amount: 100, donor: john_smith) }
+    let(:no_match) { create(:donation, amount: 100, donor: carl_grey) }
+
+    it { expect(described_class.search("smith")).to contain_exactly(match_beginning, match_middle, match_end) }
+  end
 end


### PR DESCRIPTION
This change allows users to search for a donation by entering an donor's name (or a part of it) into a search field on `events/show` page.

It also adds following missing elements on `events/show`:
- Total Amount Donated during the event
- Backlink to `events/index`

**Note:** this change contains updated `seed` files. Please run rake db:drop db:create db:migrate db:seed.

See the screenshot below:

![screencapture-localhost-3000-events-4-1476328312198](https://cloud.githubusercontent.com/assets/19661205/19335432/e05905bc-9135-11e6-9f68-bb95c32f8b1f.png)

---

**Before submitting, check that:**

 - [x] You have added (passing) tests for your code.
 - [x] You have written good* commit messages.
 - [ ] You have squashed relevant commits together.
 - [x] You have ensured that RuboCop is passing.
 - [x] Your PR relates to one subject, with a clear title and
       description using complete, grammatically correct sentences.

---

If your change contains views, ensure that:

 - [x] You have included a screenshot of the new view.

---

*If you do not know what makes a good commit message, or why it
is important, please refer to these resources: [1][1], [2][2], [3][3].

[1]: https://robots.thoughtbot.com/5-useful-tips-for-a-better-commit-message
[2]: http://chris.beams.io/posts/git-commit/
[3]: https://github.com/blog/1943-how-to-write-the-perfect-pull-request

