### PR TITLE
[Fix #13] Add datepicker options to event modal

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem "sass-rails", "~> 5.0"
 gem "rails-assets-tether", "~> 1.1.0"
 gem "bootstrap", "~> 4.0.0.alpha4"
 gem "font-awesome-rails"
+gem "bootstrap-datepicker-rails"
 
 gem "clearance"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,6 +46,8 @@ GEM
     bootstrap (4.0.0.alpha4)
       autoprefixer-rails (>= 6.0.3)
       sass (>= 3.4.19)
+    bootstrap-datepicker-rails (1.6.4.1)
+      railties (>= 3.0)
     builder (3.2.2)
     byebug (9.0.5)
     clearance (1.15.0)
@@ -203,6 +205,7 @@ PLATFORMS
 
 DEPENDENCIES
   bootstrap (~> 4.0.0.alpha4)
+  bootstrap-datepicker-rails
   byebug
   clearance
   codeclimate-test-reporter

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -15,5 +15,18 @@
 //= require jquery_ujs
 //= require turbolinks
 //= require tether
+//= require bootstrap-datepicker
 //= require bootstrap-sprockets
 //= require_tree .
+
+
+$(document).ready(function(){
+  $('.datepicker').datepicker({
+    format: "dd/mm/yyyy",
+    weekStart: 1,
+    autoclose: true,
+    todayHighlight: true
+  });
+});
+
+

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -14,4 +14,5 @@
  */
 
  @import "bootstrap";
+ @import "bootstrap-datepicker";
  @import "font-awesome";

--- a/app/views/events/_new.html.erb
+++ b/app/views/events/_new.html.erb
@@ -14,12 +14,12 @@
 
             <div class="form-group">
               <%= f.label :start_on, "Start date", class: "control-label" %>
-              <%= f.date_field :start_on, class: "form-control" %>
+              <%= f.text_field :start_on, class: "form-control datepicker" %>
             </div>
 
             <div class="form-group">
               <%= f.label :end_on, "End date", class: "control-label" %>
-              <%= f.date_field :end_on, class: "form-control" %>
+              <%= f.text_field :end_on, class: "form-control datepicker" %>
             </div>
 
             <div class="actions">


### PR DESCRIPTION
This change adds a "boostrap-datepicker" gem and lets a user pick a date using an interactive calendar.

**Note:** This change adds a gem, please run `bundle install'.

---

See screenshot below:

![screencapture-localhost-3000-events-1476353280635](https://cloud.githubusercontent.com/assets/19661205/19345214/0235546c-9170-11e6-92b3-7ab42e4e5a8b.png)


---

**Before submitting, check that:**

 - [x] You have written good* commit messages.
 - [x] You have squashed relevant commits together.
 - [x] You have ensured that RuboCop is passing.
 - [x] Your PR relates to one subject, with a clear title and
       description using complete, grammatically correct sentences.

---

If your change contains views, ensure that:

 - [x] You have included a screenshot of the new view.

---

*If you do not know what makes a good commit message, or why it
is important, please refer to these resources: [1][1], [2][2], [3][3].

[1]: https://robots.thoughtbot.com/5-useful-tips-for-a-better-commit-message
[2]: http://chris.beams.io/posts/git-commit/
[3]: https://github.com/blog/1943-how-to-write-the-perfect-pull-request


- Install "bootstra-datepicker" gem
- Initialize datepicker and add it to events modal