### PR TITLE
[Fix #30] Show only donation related to an event when viewing events

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -4,9 +4,9 @@ class EventsController < ApplicationController
   def show
     @event = find_event(params[:id])
     @donations = if params[:search]
-                   Donation.search(params[:search])
+                   @event.donations.search(params[:search])
                  else
-                   Donation.all
+                   @event.donations
                  end
   end
 

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -36,8 +36,8 @@
       </thead>
       <tbody>
         <tr>
-          <% if @donations.blank? %>
-            <h4>There is no Donation from a Donor named <%= params[:search] %>.</h4>
+          <% if @donations.blank? && params[:search].present? %>
+            <h4>There is no Donation from a Donor named "<%= params[:search] %>".</h4>
           <% end %>
         </tr>
         <% @donations.each do |donation| %>

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -51,7 +51,9 @@ RSpec.describe EventsController, type: :controller do
   end
 
   describe "GET #show" do
-    let(:event) { instance_double(Event) }
+    let(:donation) { instance_double(Donation, amount: 100) }
+    let(:event) { instance_double(Event, donations: donation) }
+
     before { get :show, id: 1 }
 
     context "when event exists" do


### PR DESCRIPTION
This change updates the `show` action for `Event` to show only `donations` related to that particular event.

---

**Before submitting, check that:**

 - [x] You have added (passing) tests for your code.
 - [x] You have written good* commit messages.
 - [ ] You have squashed relevant commits together.
 - [x] You have ensured that RuboCop is passing.
 - [x] Your PR relates to one subject, with a clear title and
       description using complete, grammatically correct sentences.

---

*If you do not know what makes a good commit message, or why it
is important, please refer to these resources: [1][1], [2][2], [3][3].

[1]: https://robots.thoughtbot.com/5-useful-tips-for-a-better-commit-message
[2]: http://chris.beams.io/posts/git-commit/
[3]: https://github.com/blog/1943-how-to-write-the-perfect-pull-request


