### PR TITLE
Allow users to search for a donor on donors/index

### DIFF
--- a/app/controllers/donors_controller.rb
+++ b/app/controllers/donors_controller.rb
@@ -6,7 +6,11 @@ class DonorsController < ApplicationController
 
   # GET /donors
   def index
-    @donors = Donor.all
+    @donors = if params[:search]
+                Donor.search(params[:search])
+              else
+                Donor.all
+              end
   end
 
   def update

--- a/app/models/donor.rb
+++ b/app/models/donor.rb
@@ -3,6 +3,8 @@ class Donor < ActiveRecord::Base
 
   validates :identification, presence: true
 
+  scope :search, -> (keyword) { where("name ILIKE ?", "%#{keyword}%") }
+
   def total_donations
     donations.sum(:amount).round
   end

--- a/app/views/donors/index.html.erb
+++ b/app/views/donors/index.html.erb
@@ -1,20 +1,46 @@
+<div class="card card-inverse card-info text-xs-center">
+  <div class="card-block">
+    <h1>Total: <%= number_with_delimiter(@donors.count, delimiter: ",") %> Donors</h1>
+  </div>
+</div>
 <div class="table-responsive">
-  <table class="table">
-    <thead class="thead-default">
-      <tr>
-        <th>Name</th>
-        <th>NRIC/UEN</th>
-        <th>Total Donation</th>
-      </tr>
-    </thead>
-    <tbody>
-      <% @donors.each do |donor| %>
+  <%= form_tag donors_path, method: :get do %>
+    <table class="table">
+      <thead class="thead-default">
         <tr>
-          <td><%= donor.name %></td>
-          <td><%= donor.identification %></td>
-          <td>$<%= number_with_delimiter(donor.total_donations, delimiter: ",") %></td>
+          <td colspan="3">
+            <div class="row">
+              <div class="col-xs-12 col-sm-6 col-md-4 offset-sm-6 offset-md-8">
+                <div class="input-group">
+                      <%= text_field_tag :search, params[:search], placeholder: "Type here...", class: "form-control" %>
+                      <span class="input-group-btn">
+                        <%= submit_tag "Search", name: :nil, class: "btn btn-secondary" %>
+                      </span>
+                </div>
+              </div>
+            </div>
+          </td>
         </tr>
-      <% end %>
-    </tbody>
-  </table>
+        <tr>
+          <th>Name</th>
+          <th>NRIC/UEN</th>
+          <th>Total Donation</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <% if @donors.blank? && params[:search].present? %>
+            <h4>There are no donors with the name "<%= params[:search] %>".</h4>
+          <% end %>
+        </tr>
+        <% @donors.each do |donor| %>
+          <tr>
+            <td><%= donor.name %></td>
+            <td><%= donor.identification %></td>
+            <td>$<%= number_with_delimiter(donor.total_donations, delimiter: ",") %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  <% end %>
 </div>

--- a/spec/models/donor_spec.rb
+++ b/spec/models/donor_spec.rb
@@ -10,4 +10,13 @@ RSpec.describe Donor, type: :model do
 
     it { expect(donor.total_donations).to eq(200) }
   end
+
+  describe ".search" do
+    let(:match_beginning) { create(:donor, name: "Smithie Black", identification: "G1234567M") }
+    let(:match_middle) { create(:donor, name: "Bob Smith-White", identification: "G1234567M") }
+    let(:match_end) { create(:donor, name: "John Smith", identification: "G1234567M") }
+    let(:no_match) { create(:donor, name: "Carl Grey", identification: "G1234567M") }
+
+    it { expect(described_class.search("smith")).to contain_exactly(match_beginning, match_middle, match_end) }
+  end
 end


### PR DESCRIPTION
This change allows users to search for donors by entering a `donor` name (or a part of it) into a search field on `donors/index` page.

Also this change lets users see the total amount of `Donors` in the system.

See the screenshot below:
---

![screencapture-localhost-3000-donors-1476410481084](https://cloud.githubusercontent.com/assets/19661205/19373252/300604ba-91f5-11e6-977a-8369202a7fd6.png)


**Before submitting, check that:**

 - [x] You have added (passing) tests for your code.
 - [x] You have written good* commit messages.
 - [ ] You have squashed relevant commits together.
 - [x] You have ensured that RuboCop is passing.
 - [x] Your PR relates to one subject, with a clear title and
       description using complete, grammatically correct sentences.

---


If your change contains views, ensure that:

 - [x] You have included a screenshot of the new view.

---

*If you do not know what makes a good commit message, or why it
is important, please refer to these resources: [1][1], [2][2], [3][3].

[1]: https://robots.thoughtbot.com/5-useful-tips-for-a-better-commit-message
[2]: http://chris.beams.io/posts/git-commit/
[3]: https://github.com/blog/1943-how-to-write-the-perfect-pull-request

