### PR TITLE
Allow user to choose both cause and event when creating donation

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,7 +38,7 @@ GEM
       tzinfo (~> 1.1)
     arel (6.0.3)
     ast (2.3.0)
-    autoprefixer-rails (6.5.0.2)
+    autoprefixer-rails (6.5.1)
       execjs
     bcrypt (3.1.11)
     binding_of_caller (0.7.2)
@@ -49,8 +49,8 @@ GEM
     bootstrap-datepicker-rails (1.6.4.1)
       railties (>= 3.0)
     builder (3.2.2)
-    byebug (9.0.5)
-    clearance (1.15.0)
+    byebug (9.0.6)
+    clearance (1.15.1)
       bcrypt
       email_validator (~> 1.4)
       rails (>= 3.1)
@@ -153,7 +153,7 @@ GEM
       rspec-mocks (~> 3.5.0)
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
-    rubocop (0.43.0)
+    rubocop (0.44.1)
       parser (>= 2.3.1.1, < 3.0)
       powerpack (~> 0.1)
       rainbow (>= 1.99.1, < 3.0)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,5 +9,6 @@ class ApplicationController < ActionController::Base
 
   def prepare_modal_donation
     @modal_donation = Donation.new
+    @modal_donation.build_donor
   end
 end

--- a/app/controllers/donations_controller.rb
+++ b/app/controllers/donations_controller.rb
@@ -4,9 +4,9 @@ class DonationsController < ApplicationController
     @donation = Donation.new(donation_params)
 
     if @donation.save
-      redirect_to donations_path, notice: "Donation was successfully created."
+      redirect_to donor_path(@donation.donor), notice: "Donation was successfully created."
     else
-      redirect_to donations_path, error: @event.errors.full_messages.to_sentence
+      redirect_to :back, error: @donation.errors.full_messages.to_sentence
     end
   end
 
@@ -31,6 +31,6 @@ class DonationsController < ApplicationController
   end
 
   def donation_params
-    params.require(:donation).permit(:amount, :cause_id, :event_id)
+    params.require(:donation).permit(:amount, :cause_id, :event_id, donor_attributes: [:identification])
   end
 end

--- a/app/models/donation.rb
+++ b/app/models/donation.rb
@@ -3,6 +3,8 @@ class Donation < ActiveRecord::Base
   belongs_to :cause, inverse_of: :donations
   belongs_to :event, inverse_of: :donations
 
+  accepts_nested_attributes_for :donor
+
   validates :donor, presence: true
   validates :amount, presence: true, numericality: { greater_than: 0 }
 

--- a/app/views/donations/_new.html.erb
+++ b/app/views/donations/_new.html.erb
@@ -7,10 +7,13 @@
         </button>
 
         <%= form_for(@modal_donation) do |f| %>
+
+          <%= f.fields_for :donor, @modal_donation.donor do |donor| %>
             <div class="form-group">
-              <label for="donorDocs" class="form-control-label">Donor NRIC/UEN Number</label>
-              <input type="text" class="form-control" id="donorDocs">
+              <label for="donorDocs" class="form-control-label">Donor NRIC/UEN</label>
+              <%= donor.text_field :identification, class: "form-control" %>
             </div>
+          <% end %>
 
         <div class="form-group">
           <%= f.label :amount, class: "control-label" %>
@@ -18,8 +21,13 @@
         </div>
 
         <div class="form-group">
-          <label for="causeOrEvent" class="form-control-label">Cause or Event:</label>
-          <input type="text" class="form-control" id="causeOrEvent">
+          <label for="causeOrEvent" class="form-control-label">Cause</label>
+          <%= f.select :cause_id, options_for_select(Cause.pluck(:name, :id)), {}, class:"form-control" %>
+        </div>
+
+        <div class="form-group">
+          <label for="causeOrEvent" class="form-control-label">Event</label>
+          <%= f.select :event_id, options_for_select(Event.pluck(:name, :id)), {}, class:"form-control" %>
         </div>
 
         <div class="actions">

--- a/app/views/donors/index.html.erb
+++ b/app/views/donors/index.html.erb
@@ -36,7 +36,7 @@
         <% @donors.each do |donor| %>
           <tr>
             <td><%= donor.name %></td>
-            <td><%= donor.identification %></td>
+            <td><%= link_to donor_path(donor) do %><%= donor.identification %><% end %></td>
             <td>$<%= number_with_delimiter(donor.total_donations, delimiter: ",") %></td>
           </tr>
         <% end %>


### PR DESCRIPTION
This change allows a user to choose both cause and event when creating a donation.

Screenshot of form:
![screen shot 2016-10-15 at 3 25 46 pm](https://cloud.githubusercontent.com/assets/16523290/19408275/c6f939ae-92eb-11e6-83d7-558122b132df.png)


---

**Before submitting, check that:**

 - [ ] You have added (passing) tests for your code.
 - [x] You have written good* commit messages.
 - [x] You have squashed relevant commits together.
 - [x] You have ensured that RuboCop is passing.
 - [x] Your PR relates to one subject, with a clear title and
       description using complete, grammatically correct sentences.

---

If your change contains views, ensure that:

 - [x] You have included a screenshot of the new view.

---

*If you do not know what makes a good commit message, or why it
is important, please refer to these resources: [1][1], [2][2], [3][3].

[1]: https://robots.thoughtbot.com/5-useful-tips-for-a-better-commit-message
[2]: http://chris.beams.io/posts/git-commit/
[3]: https://github.com/blog/1943-how-to-write-the-perfect-pull-request


