### PR TITLE
Allow user to create donation with anonymous donor

### DIFF
--- a/app/views/donations/_new.html.erb
+++ b/app/views/donations/_new.html.erb
@@ -11,7 +11,7 @@
           <%= f.fields_for :donor, @modal_donation.donor do |donor| %>
             <div class="form-group">
               <label for="donorDocs" class="form-control-label">Donor NRIC/UEN</label>
-              <%= donor.text_field :identification, class: "form-control" %>
+              <%= donor.text_field :identification, class: "form-control", placeholder: "Enter 'Anonymous' if unknown" %>
             </div>
           <% end %>
 

--- a/db/seeds/donors.rb
+++ b/db/seeds/donors.rb
@@ -1,6 +1,13 @@
 puts "Seeding Donors ..."
 
 donors = [
+  identification: "Anonymous",
+  name: "Anonymous",
+  address: "",
+  phone_number: "",
+  email_address: ""
+],
+[
   identification: "G1234567M",
   name: "John Smith",
   address: "123 Street, 0123456 Singapore",


### PR DESCRIPTION
This change allows users to create a donation with an anonymous donor.

An anonymous donor is added to the seed file.

Screenshot of the form:
![screen shot 2016-10-15 at 4 43 52 pm](https://cloud.githubusercontent.com/assets/16523290/19408717/a4fc40ca-92f6-11e6-914c-5de0b90c491f.png)

---

**Before submitting, check that:**

 - [ ] You have added (passing) tests for your code.
 - [x] You have written good* commit messages.
 - [x] You have squashed relevant commits together.
 - [x] You have ensured that RuboCop is passing.
 - [x] Your PR relates to one subject, with a clear title and
       description using complete, grammatically correct sentences.

---

If your change contains views, ensure that:

 - [x] You have included a screenshot of the new view.

---

*If you do not know what makes a good commit message, or why it
is important, please refer to these resources: [1][1], [2][2], [3][3].

[1]: https://robots.thoughtbot.com/5-useful-tips-for-a-better-commit-message
[2]: http://chris.beams.io/posts/git-commit/
[3]: https://github.com/blog/1943-how-to-write-the-perfect-pull-request


