### PR TITLE
[Fix #41] Remove horizontal scrollbars from tables

### DIFF
--- a/app/views/donors/index.html.erb
+++ b/app/views/donors/index.html.erb
@@ -9,13 +9,15 @@
       <thead class="thead-default">
         <tr>
           <td colspan="3">
-            <div class="row">
-              <div class="col-xs-12 col-sm-6 col-md-4 offset-sm-6 offset-md-8">
-                <div class="input-group">
-                      <%= text_field_tag :search, params[:search], placeholder: "Type here...", class: "form-control" %>
-                      <span class="input-group-btn">
-                        <%= submit_tag "Search", name: :nil, class: "btn btn-secondary" %>
-                      </span>
+            <div class="container-fluid">
+              <div class="row">
+                <div class="col-xs-12 col-sm-6 col-md-4 offset-sm-6 offset-md-8">
+                  <div class="input-group">
+                    <%= text_field_tag :search, params[:search], placeholder: "Search by donor name ...", class: "form-control" %>
+                    <span class="input-group-btn">
+                      <%= submit_tag "Search", name: :nil, class: "btn btn-secondary" %>
+                    </span>
+                  </div>
                 </div>
               </div>
             </div>
@@ -24,13 +26,13 @@
         <tr>
           <th>Name</th>
           <th>NRIC/UEN</th>
-          <th>Total Donation</th>
+          <th>Total Donations</th>
         </tr>
       </thead>
       <tbody>
         <tr>
           <% if @donors.blank? && params[:search].present? %>
-            <h4>There are no donors with the name "<%= params[:search] %>".</h4>
+            <h4>There are no donors matching <em><%= params[:search] %></em>.</h4>
           <% end %>
         </tr>
         <% @donors.each do |donor| %>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -4,25 +4,27 @@
     <h1>Events</h1>
   </div>
   <div class="col-xs-12 col-sm-4 offset-sm-4 eventsButton">
-	<button type="button" class="btn btn-primary pull-right" data-toggle="modal" data-target="#eventModal">
-	  <i class="fa fa-plus" aria-hidden="true"></i>
-	  Add New Event
-	</button>
+  	<button type="button" class="btn btn-primary pull-right" data-toggle="modal" data-target="#eventModal">
+  	  <i class="fa fa-plus" aria-hidden="true"></i>
+  	  Add New Event
+  	</button>
   </div>
 </div>
 <div class="table-responsive">
   <%= form_tag events_path, method: :get do %>
     <table class="table">
-      <thead >
+      <thead>
         <tr>
           <td colspan="3">
-            <div class="row">
-              <div class="col-xs-12 col-sm-6 col-md-4 offset-sm-6 offset-md-8">
-                <div class="input-group">
-                      <%= text_field_tag :search, params[:search], placeholder: "Type here...", class: "form-control" %>
-                      <span class="input-group-btn">
-                        <%= submit_tag "Search", name: :nil, class: "btn btn-secondary" %>
-                      </span>
+            <div class="container-fluid">
+              <div class="row">
+                <div class="col-xs-12 col-sm-6 col-md-4 offset-sm-6 offset-md-8">
+                  <div class="input-group">
+                    <%= text_field_tag :search, params[:search], placeholder: "Search by event name ...", class: "form-control" %>
+                    <span class="input-group-btn">
+                      <%= submit_tag "Search", name: :nil, class: "btn btn-secondary" %>
+                    </span>
+                  </div>
                 </div>
               </div>
             </div>
@@ -37,7 +39,7 @@
       <tbody>
         <tr>
           <% if @events.blank? %>
-            <h4>There are no events containing the term <%= params[:search] %>.</h4>
+            <h4>There are no events matching <em><%= params[:search] %></em>.</h4>
           <% end %>
         </tr>
         <% @events.each do |event| %>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -16,13 +16,15 @@
       <thead class="thead-default">
         <tr>
           <td colspan="3">
-            <div class="row">
-              <div class="col-xs-12 col-sm-6 col-md-4 offset-sm-6 offset-md-8">
-                <div class="input-group">
-                      <%= text_field_tag :search, params[:search], placeholder: "Type here...", class: "form-control" %>
-                      <span class="input-group-btn">
-                        <%= submit_tag "Search", name: :nil, class: "btn btn-secondary" %>
-                      </span>
+            <div class="container-fluid">
+              <div class="row">
+                <div class="col-xs-12 col-sm-6 col-md-4 offset-sm-6 offset-md-8">
+                  <div class="input-group">
+                    <%= text_field_tag :search, params[:search], placeholder: "Search by donor name ...", class: "form-control" %>
+                    <span class="input-group-btn">
+                      <%= submit_tag "Search", name: :nil, class: "btn btn-secondary" %>
+                    </span>
+                  </div>
                 </div>
               </div>
             </div>
@@ -37,7 +39,7 @@
       <tbody>
         <tr>
           <% if @donations.blank? && params[:search].present? %>
-            <h4>There is no Donation from a Donor named "<%= params[:search] %>".</h4>
+            <h4>There is no donor matching <em><%= params[:search] %></em>.</h4>
           <% end %>
         </tr>
         <% @donations.each do |donation| %>


### PR DESCRIPTION
There was an issue with the Bootstrap grid, caused by the search row not being wrapped in a container. This change fixes that in all three places:

<img width="1122" alt="screen shot 2016-10-15 at 17 23 15" src="https://cloud.githubusercontent.com/assets/5259935/19408970/229ee3e8-92fc-11e6-9d4b-348143dc775d.png">

<img width="1123" alt="screen shot 2016-10-15 at 17 23 26" src="https://cloud.githubusercontent.com/assets/5259935/19408972/296251d8-92fc-11e6-9030-9252f16bfb1a.png">

<img width="1115" alt="screen shot 2016-10-15 at 17 23 36" src="https://cloud.githubusercontent.com/assets/5259935/19408974/301c8fac-92fc-11e6-8b7a-c6b0eaa412b8.png">

It also solves some small problems, like indentation issues and typos.

---

**Before submitting, check that:**

 - [X] You have written good* commit messages.
 - [X] You have squashed relevant commits together.
 - [X] You have ensured that RuboCop is passing.
 - [X] Your PR relates to one subject, with a clear title and
       description using complete, grammatically correct sentences.

---

If your change contains views, ensure that:

 - [X] You have included a screenshot of the new view.

---

*If you do not know what makes a good commit message, or why it
is important, please refer to these resources: [1][1], [2][2], [3][3].

[1]: https://robots.thoughtbot.com/5-useful-tips-for-a-better-commit-message
[2]: http://chris.beams.io/posts/git-commit/
[3]: https://github.com/blog/1943-how-to-write-the-perfect-pull-request