### PR TITLE
[Fix #42] Prevent duplicate donors from being created when adding donations

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,6 +11,9 @@ AllCops:
 Rails:
   Enabled: true
 
+Rails/HttpPositionalArguments:
+  Enabled: false
+
 Style/AccessorMethodName:
   Enabled: false
 

--- a/app/controllers/donations_controller.rb
+++ b/app/controllers/donations_controller.rb
@@ -1,7 +1,8 @@
 class DonationsController < ApplicationController
   # POST /donations
   def create
-    @donation = Donation.new(donation_params)
+    donor = find_or_build_donor(donation_params.delete(:donor))
+    @donation = Donation.new(donation_params.merge(donor: donor))
 
     if @donation.save
       redirect_to donor_path(@donation.donor), notice: "Donation was successfully created."
@@ -10,8 +11,10 @@ class DonationsController < ApplicationController
     end
   end
 
+  # PATCH /update
   def update
     @donation = find_donation(params[:id])
+
     if @donation.update(donation_params)
       redirect_to donor_path(@donation.donor), notice: "Donation was successfully updated."
     else
@@ -19,8 +22,10 @@ class DonationsController < ApplicationController
     end
   end
 
+  # GET /edit
   def edit
     @donation = find_donation(params[:id])
+
     render :edit
   end
 
@@ -30,7 +35,11 @@ class DonationsController < ApplicationController
     Donation.find(id)
   end
 
+  def find_or_build_donor(id)
+    Donor.find_or_initialize_by(id)
+  end
+
   def donation_params
-    params.require(:donation).permit(:amount, :cause_id, :event_id, donor_attributes: [:identification])
+    params.require(:donation).permit(:amount, :cause_id, :event_id, donor: [:identification])
   end
 end

--- a/app/models/donation.rb
+++ b/app/models/donation.rb
@@ -3,8 +3,6 @@ class Donation < ActiveRecord::Base
   belongs_to :cause, inverse_of: :donations
   belongs_to :event, inverse_of: :donations
 
-  accepts_nested_attributes_for :donor
-
   validates :donor, presence: true
   validates :amount, presence: true, numericality: { greater_than: 0 }
 

--- a/app/models/donor.rb
+++ b/app/models/donor.rb
@@ -1,7 +1,7 @@
 class Donor < ActiveRecord::Base
   has_many :donations, inverse_of: :donor
 
-  validates :identification, presence: true
+  validates :identification, presence: true, uniqueness: true
 
   scope :search, -> (keyword) { where("name ILIKE ?", "%#{keyword}%") }
 

--- a/db/migrate/20160926083804_create_donors.rb
+++ b/db/migrate/20160926083804_create_donors.rb
@@ -10,5 +10,8 @@ class CreateDonors < ActiveRecord::Migration
 
       t.timestamps null: false
     end
+
+    add_index :donors, :identification, unique: true
+    add_index :donors, :name
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -46,6 +46,9 @@ ActiveRecord::Schema.define(version: 20160929164755) do
     t.datetime "updated_at",     null: false
   end
 
+  add_index "donors", ["identification"], name: "index_donors_on_identification", unique: true, using: :btree
+  add_index "donors", ["name"], name: "index_donors_on_name", using: :btree
+
   create_table "events", force: :cascade do |t|
     t.string   "name",       null: false
     t.date     "start_on",   null: false

--- a/db/seeds/donations.rb
+++ b/db/seeds/donations.rb
@@ -7,7 +7,7 @@ donations = [
   event: Event.first
 ],
 [
-  donor: Donor.second,
+  donor: Donor.last,
   cause: Cause.first,
   amount: 200,
   event: Event.first

--- a/spec/factories/donors.rb
+++ b/spec/factories/donors.rb
@@ -1,6 +1,10 @@
 FactoryGirl.define do
+  sequence :identification do |n|
+    "G123456#{n}M"
+  end
+
   factory :donor do
-    identification "G1234567M"
+    identification
 
     trait :invalid do
       identification nil

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -6,5 +6,9 @@ FactoryGirl.define do
   factory :user do
     email
     password "password"
+
+    trait :invalid do
+      email nil
+    end
   end
 end

--- a/spec/models/donation_spec.rb
+++ b/spec/models/donation_spec.rb
@@ -9,10 +9,10 @@ RSpec.describe Donation, type: :model do
   it { is_expected.to validate_numericality_of(:amount).is_greater_than(0) }
 
   describe ".search" do
-    let(:smithie_black) { create(:donor, name: "Smithie Black", identification: "G1234567M") }
-    let(:bob_smith_white) { create(:donor, name: "Bob Smith-White", identification: "G1234567M") }
-    let(:john_smith) { create(:donor, name: "John Smith", identification: "G1234567M") }
-    let(:carl_grey) { create(:donor, name: "Carl Grey", identification: "G1234567M") }
+    let(:smithie_black) { create(:donor, name: "Smithie Black") }
+    let(:bob_smith_white) { create(:donor, name: "Bob Smith-White") }
+    let(:john_smith) { create(:donor, name: "John Smith") }
+    let(:carl_grey) { create(:donor, name: "Carl Grey") }
 
     let(:match_beginning) { create(:donation, amount: 100, donor: smithie_black) }
     let(:match_middle) { create(:donation, amount: 100, donor: bob_smith_white) }

--- a/spec/models/donor_spec.rb
+++ b/spec/models/donor_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 RSpec.describe Donor, type: :model do
+  subject { build(:donor) }
+
   it { is_expected.to have_many(:donations).inverse_of(:donor) }
 
   it { is_expected.to validate_presence_of(:identification) }

--- a/spec/models/donor_spec.rb
+++ b/spec/models/donor_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe Donor, type: :model do
   it { is_expected.to have_many(:donations).inverse_of(:donor) }
 
   it { is_expected.to validate_presence_of(:identification) }
+  it { is_expected.to validate_uniqueness_of(:identification) }
 
   describe "#total_donations" do
     let(:donor) { create(:donor_with_donations) }
@@ -12,10 +13,10 @@ RSpec.describe Donor, type: :model do
   end
 
   describe ".search" do
-    let(:match_beginning) { create(:donor, name: "Smithie Black", identification: "G1234567M") }
-    let(:match_middle) { create(:donor, name: "Bob Smith-White", identification: "G1234567M") }
-    let(:match_end) { create(:donor, name: "John Smith", identification: "G1234567M") }
-    let(:no_match) { create(:donor, name: "Carl Grey", identification: "G1234567M") }
+    let(:match_beginning) { create(:donor, name: "Smithie Black") }
+    let(:match_middle) { create(:donor, name: "Bob Smith-White") }
+    let(:match_end) { create(:donor, name: "John Smith") }
+    let(:no_match) { create(:donor, name: "Carl Grey") }
 
     it { expect(described_class.search("smith")).to contain_exactly(match_beginning, match_middle, match_end) }
   end


### PR DESCRIPTION
This change forces `Donor#identification` to be unique both at the application- and database level, since only one person or organization can have the unique identification.

That fixes the issue where creating a donation from the quick donation modal would create a duplicate donor for the donation instead of it being attributed to the existing donor.

It also improves the seeds, so that there's now one donor with no donations, one with one donation, and one with several.

---

**Before submitting, check that:**

 - [X] You have written good* commit messages.
 - [X] You have squashed relevant commits together.
 - [X] You have ensured that RuboCop is passing.
 - [X] Your PR relates to one subject, with a clear title and
       description using complete, grammatically correct sentences.

---

If your change contains models, ensure that:

 - [X] You have added database seeds for the model.
 - [X] You have added working factories for the model.
 - [X] Your validations have corresponding database constraints.

---

*If you do not know what makes a good commit message, or why it
is important, please refer to these resources: [1][1], [2][2], [3][3].

[1]: https://robots.thoughtbot.com/5-useful-tips-for-a-better-commit-message
[2]: http://chris.beams.io/posts/git-commit/
[3]: https://github.com/blog/1943-how-to-write-the-perfect-pull-request

