### PR TITLE
[Fix #44] Fix gap issue in .input-group between input-field and button

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -16,3 +16,7 @@
  @import "bootstrap";
  @import "bootstrap-datepicker";
  @import "font-awesome";
+
+ table .input-group {
+  border-collapse: collapse;
+ }


### PR DESCRIPTION
This change add CSS that removes small space between `input-field` and `button` in `input-group`.

It is a known issue (https://github.com/twbs/bootstrap/issues/20404), so the CSS added is a work-around until the issue is fixed by Bootstrap.

---

See the screenshot below:

![screen shot 2016-10-17 at 2 24 30 pm 1](https://cloud.githubusercontent.com/assets/19661205/19427278/853317f2-9475-11e6-9665-e7f47c81ac2e.png)

---

**Before submitting, check that:**

 - [x] You have added (passing) tests for your code.
 - [x] You have written good* commit messages.
 - [x] You have squashed relevant commits together.
 - [x] You have ensured that RuboCop is passing.
 - [x] Your PR relates to one subject, with a clear title and
       description using complete, grammatically correct sentences.

---

If your change contains views, ensure that:

 - [x] You have included a screenshot of the new view.

---

*If you do not know what makes a good commit message, or why it
is important, please refer to these resources: [1][1], [2][2], [3][3].

[1]: https://robots.thoughtbot.com/5-useful-tips-for-a-better-commit-message
[2]: http://chris.beams.io/posts/git-commit/
[3]: https://github.com/blog/1943-how-to-write-the-perfect-pull-request


