### PR TITLE
[Fix #36] Improve date format of donations on the donor show page

### DIFF
--- a/app/views/donors/show.html.erb
+++ b/app/views/donors/show.html.erb
@@ -18,7 +18,7 @@
   <table class="table">
     <thead class="thead-default">
       <tr>
-        <th>Date Created</th>
+        <th>Donated on</th>
         <th>Amount</th>
         <th>Cause</th>
         <th>Event</th>
@@ -28,7 +28,7 @@
     <tbody>
       <% @donor.donations.each do |donation| %>
       <tr>
-        <td><%= donation.created_at.to_formatted_s(:short) %> (<%= donation.created_at.strftime("%Y") %>)</td>
+        <td><%= l donation.created_at.to_date, format: donation.created_at.year == Date.today.year ? :short : :default %> </td>
         <td>$<%= donation.amount.to_i %></td>
         <td><%= donation.cause.name %></td>
         <td><% if donation.event %><%= donation.event.name %><% end %></td>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -22,6 +22,6 @@
 en:
   date:
     formats:
-      default: "%d %b %Y"
+      default: "%d %b, %Y"
       short: "%d %b"
 


### PR DESCRIPTION
This change improves the date formatting on `donor/show` page. The year is shown only of the `donation` was made not during the current year. 

---

See the screenshot below:

![screen shot 2016-10-17 at 2 57 39 pm](https://cloud.githubusercontent.com/assets/19661205/19428015/16a55322-947a-11e6-8dcc-7c4fbab38f8a.png)

**Before submitting, check that:**

 - [x] You have added (passing) tests for your code.
 - [x] You have written good* commit messages.
 - [x] You have squashed relevant commits together.
 - [x] You have ensured that RuboCop is passing.
 - [x] Your PR relates to one subject, with a clear title and
       description using complete, grammatically correct sentences.

---

If your change contains views, ensure that:

 - [x] You have included a screenshot of the new view.

---

*If you do not know what makes a good commit message, or why it
is important, please refer to these resources: [1][1], [2][2], [3][3].

[1]: https://robots.thoughtbot.com/5-useful-tips-for-a-better-commit-message
[2]: http://chris.beams.io/posts/git-commit/
[3]: https://github.com/blog/1943-how-to-write-the-perfect-pull-request


