### PR TITLE
[Fix #40] Allow user edit Donations for Donor

### DIFF
--- a/app/controllers/donations_controller.rb
+++ b/app/controllers/donations_controller.rb
@@ -26,7 +26,9 @@ class DonationsController < ApplicationController
   def edit
     @donation = find_donation(params[:id])
 
-    render :edit
+    respond_to do |format|
+      format.js
+    end
   end
 
   private

--- a/app/models/donation.rb
+++ b/app/models/donation.rb
@@ -1,4 +1,6 @@
 class Donation < ActiveRecord::Base
+  default_scope { order(created_at: :desc) }
+
   belongs_to :donor, inverse_of: :donations
   belongs_to :cause, inverse_of: :donations
   belongs_to :event, inverse_of: :donations

--- a/app/views/donations/_edit.html.erb
+++ b/app/views/donations/_edit.html.erb
@@ -1,34 +1,14 @@
-<div class="modal fade" id="donationeditModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
-  <div class="modal-dialog modal-sm" role="document">
-    <div class="modal-content">
-      <div class="modal-body">
-        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-          <span aria-hidden="true">&times;</span>
-        </button>
-
-        <% @donor.donations.each do |donation| %>
-          <%= form_for(donation) do |f| %>
-          <div class="form-group">
-            <%= f.label :amount, class: "control-label" %>
-            <%= f.text_field :amount, class: "form-control" %>
-          </div>
-
-          <div class="form-group">
-            <label for="causeOrEvent" class="form-control-label">Cause:</label>
-            <%= f.select :cause_id, options_for_select(Cause.pluck(:name, :id)), {}, class:"form-control" %>
-          </div>
-
-          <div class="form-group">
-            <label for="causeOrEvent" class="form-control-label">Event:</label>
-            <%= f.select :event_id, options_for_select(Event.pluck(:name, :id)), {}, class:"form-control" %>
-          </div>
-
-          <div class="actions">
-            <%= f.submit "Save changes", class: "btn btn-primary form-control" %>
-          </div>
-          <% end %>
-        <% end %>
-      </div>
+<div class="modal-dialog modal-sm" role="document">
+  <div class="modal-content">
+    <div class="modal-body">
+      <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+        <span aria-hidden="true">&times;</span>
+      </button>
+      <h5>Edit Donation Details</h5>
+      <%= form_for(@donation) do |f| %>
+        <%= render "form", f: f  %>
+      <% end %>
     </div>
   </div>
 </div>
+

--- a/app/views/donations/_form.html.erb
+++ b/app/views/donations/_form.html.erb
@@ -1,0 +1,18 @@
+<div class="form-group">
+  <%= f.label :amount, class: "control-label" %>
+  <%= f.text_field :amount, class: "form-control" %>
+</div>
+
+<div class="form-group">
+  <label for="causeOrEvent" class="form-control-label">Cause:</label>
+  <%= f.select :cause_id, Cause.pluck(:name, :id), {}, class:"form-control" %>
+</div>
+
+<div class="form-group">
+  <label for="causeOrEvent" class="form-control-label">Event:</label>
+  <%= f.select :event_id, Event.pluck(:name, :id), {}, class:"form-control" %>
+</div>
+
+<div class="actions">
+  <%= f.submit "Save changes", class: "btn btn-primary form-control" %>
+</div>

--- a/app/views/donations/_new.html.erb
+++ b/app/views/donations/_new.html.erb
@@ -5,35 +5,15 @@
         <button type="button" class="close" data-dismiss="modal" aria-label="Close">
           <span aria-hidden="true">&times;</span>
         </button>
-
+        <h5>Donation Details</h5>
         <%= form_for(@modal_donation) do |f| %>
-
           <%= f.fields_for :donor, @modal_donation.donor do |donor| %>
             <div class="form-group">
               <label for="donorDocs" class="form-control-label">Donor NRIC/UEN</label>
               <%= donor.text_field :identification, class: "form-control", placeholder: "Enter 'Anonymous' if unknown" %>
             </div>
           <% end %>
-
-        <div class="form-group">
-          <%= f.label :amount, class: "control-label" %>
-          <%= f.text_field :amount, class: "form-control" %>
-        </div>
-
-        <div class="form-group">
-          <label for="causeOrEvent" class="form-control-label">Cause</label>
-          <%= f.select :cause_id, options_for_select(Cause.pluck(:name, :id)), {}, class:"form-control" %>
-        </div>
-
-        <div class="form-group">
-          <label for="causeOrEvent" class="form-control-label">Event</label>
-          <%= f.select :event_id, options_for_select(Event.pluck(:name, :id)), {}, class:"form-control" %>
-        </div>
-
-        <div class="actions">
-          <%= f.submit class: "btn btn-primary form-control" %>
-        </div>
-
+          <%= render "donations/form", f: f  %>
         <% end %>
       </div>
     </div>

--- a/app/views/donations/edit.js.erb
+++ b/app/views/donations/edit.js.erb
@@ -1,0 +1,3 @@
+$("#editDonation").empty()
+$("#editDonation").append("<%= j render partial: 'donations/edit' %>");
+$("#editDonation").modal("show");

--- a/app/views/donors/edit.js.erb
+++ b/app/views/donors/edit.js.erb
@@ -1,2 +1,2 @@
-$('#edit_partial').html("<%= escape_javascript(render('edit')) %>");
+$("#edit_partial").html("<%= escape_javascript(render('edit')) %>");
 $("#show_partial").hide();

--- a/app/views/donors/show.html.erb
+++ b/app/views/donors/show.html.erb
@@ -30,10 +30,11 @@
       <tr>
         <td><%= l donation.created_at.to_date, format: donation.created_at.year == Date.today.year ? :short : :default %> </td>
         <td>$<%= donation.amount.to_i %></td>
-        <td><%= donation.cause.name %></td>
-        <td><% if donation.event %><%= donation.event.name %><% end %></td>
-        <td><%= link_to edit_donation_path, data: {toggle: "modal", target: "#donationeditModal"} do %>
-          <i class="fa fa-pencil fa-lg"></i>
+        <td><%= donation.cause&.name %></td>
+        <td><%= donation.event&.name %></td>
+        <td>
+          <%= link_to edit_donation_path(donation), remote: true  do %>
+            <i class="fa fa-pencil fa-lg"></i>
           <% end %>
         </td>
       </tr>
@@ -42,6 +43,4 @@
   </table>
 </div>
 
-<div>
-  <%= render "donations/edit" %>
-</div>
+<div id="editDonation" class="modal fade" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true"></div>

--- a/app/views/events/_new.html.erb
+++ b/app/views/events/_new.html.erb
@@ -7,25 +7,24 @@
         </button>
         <h4 class="modal-title">Event Details</h4>
         <%= form_for(@modal_event) do |f| %>
-            <div class="form-group">
-              <%= f.label :name, "Event Name", class: "control-label" %>
-              <%= f.text_field :name, class: "form-control" %>
-            </div>
+          <div class="form-group">
+            <%= f.label :name, "Event Name", class: "control-label" %>
+            <%= f.text_field :name, class: "form-control" %>
+          </div>
 
-            <div class="form-group">
-              <%= f.label :start_on, "Start date", class: "control-label" %>
-              <%= f.text_field :start_on, class: "form-control datepicker" %>
-            </div>
+          <div class="form-group">
+            <%= f.label :start_on, "Start Date", class: "control-label" %>
+            <%= f.text_field :start_on, class: "form-control datepicker" %>
+          </div>
 
-            <div class="form-group">
-              <%= f.label :end_on, "End date", class: "control-label" %>
-              <%= f.text_field :end_on, class: "form-control datepicker" %>
-            </div>
+          <div class="form-group">
+            <%= f.label :end_on, "End Date", class: "control-label" %>
+            <%= f.text_field :end_on, class: "form-control datepicker" %>
+          </div>
 
-            <div class="actions">
-              <%= f.submit class: "btn btn-primary form-control" %>
-            </div>
-
+          <div class="actions">
+            <%= f.submit class: "btn btn-primary form-control" %>
+          </div>
         <% end %>
       </div>
     </div>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -2,22 +2,24 @@
   <div class="collapse navbar-toggleable-xs" id="exCollapsingNavbar2">
     <ul class="nav navbar-nav">
       <li class="nav-item">
-        <%= link_to 'Donors', donors_path %>
+        <%= link_to "Donors", donors_path %>
       </li>
       <li class="nav-item">
-        <%= link_to 'Events', events_path %>
+        <%= link_to "Events", events_path %>
       </li>
       <li class="nav-item pull-sm-right">
         <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#donationModal">
           <i class="fa fa-plus" aria-hidden="true"></i>
           New donation
         </button>
-  <div class="btn-group">
-    <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-      <%= current_user.email %> <span class="caret"></span>
-    </button>
-    <ul class="dropdown-menu">
-      <li><%= link_to 'Sign out', sign_out_path, method: :delete %></li>
+        <div class="btn-group">
+          <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            <%= current_user.email %> <span class="caret"></span>
+          </button>
+          <div class="dropdown-menu dropdown-menu-right">
+            <button class="dropdown-item" type="button"><%= link_to "Sign out", sign_out_path, method: :delete %></button>
+          </div>
+        </div>
       </li>
     </ul>
   </div>

--- a/db/seeds/donations.rb
+++ b/db/seeds/donations.rb
@@ -7,16 +7,22 @@ donations = [
   event: Event.first
 ],
 [
-  donor: Donor.last,
+  donor: Donor.second,
   cause: Cause.first,
   amount: 200,
   event: Event.first
 ],
 [
-  donor: Donor.last,
+  donor: Donor.second,
   cause: Cause.first,
   amount: 300,
-  event: Event.first
+  event: Event.second
+],
+[
+  donor: Donor.second,
+  cause: Cause.first,
+  amount: 400,
+  event: Event.third
 ]
 
 unless Donation.any?

--- a/spec/controllers/donations_controller_spec.rb
+++ b/spec/controllers/donations_controller_spec.rb
@@ -1,28 +1,47 @@
 require "rails_helper"
 
 RSpec.describe DonationsController, type: :controller do
-  let(:donation) { instance_double(Donation) }
-
   before do
-    allow(donation).to receive(:save) { save_result }
+    sign_in
     allow(subject).to receive(:find_donation) { donation }
   end
 
   describe "POST #create" do
+    let(:donor) { Donor.create(identification: "N111111") }
+    let(:donation) { Donation.create(amount: 100, donor: donor) }
+
     before do
+      allow(donation).to receive(:save) { save_result }
       post :create, donation: attributes_for(:donation)
     end
 
-    context "when donor is saved successfully" do
+    context "when donation is saved successfully" do
       let(:save_result) { true }
 
-      it { expect(response).to have_http_status(:found) }
+      it { expect(response).to redirect_to(donor_path(donation.donor)) }
     end
 
-    context "when donor is not saved successfully" do
+    context "when donation is not saved successfully" do
       let(:save_result) { false }
 
       it { expect(response).to have_http_status(:found) }
     end
+  end
+
+  describe "PUT #update/:id" do
+    let(:donor) { Donor.create(identification: "N111111") }
+    let(:donation) { Donation.create(amount: 100, donor: donor) }
+    let(:cause) { Cause.create(shortcode: "TC", name: "Test Cause") }
+    let(:event) { Event.create(name: "Test Event", start_on: "2015-10-19", end_on: "2015-10-20") }
+    let(:attr) { { amount: 200, cause_id: cause.id, event_id: event.id } }
+
+    before(:each) do
+      put :update, id: donation.id, donation: attr
+      donation.reload
+    end
+
+    it { expect(donation.amount).to eq attr[:amount] }
+    it { expect(donation.cause_id).to eq cause.id }
+    it { expect(donation.event_id).to eq event.id }
   end
 end

--- a/spec/routing/donations_routing_spec.rb
+++ b/spec/routing/donations_routing_spec.rb
@@ -2,4 +2,6 @@ require "rails_helper"
 
 RSpec.describe DonationsController, type: :routing do
   it { expect(post: "donations").to route_to("donations#create") }
+  it { expect(put: "donations/1").to route_to(controller: "donations", action: "update", id: "1") }
+  it { expect(get: "donations/1/edit").to route_to(controller: "donations", action: "edit", id: "1") }
 end


### PR DESCRIPTION
This change allows a User to edit `donations` on `donors/show` page in a modal.

**Note:** This change contains edited seed files. Please run `rake db:drop db:create db:migrate db:seed`

This change also:

- Sets a default order when showing `donations`
- Has minor edits to the `navbar` layout

---

See screenshots below:

![screencapture-localhost-3000-donors-2-1476842687272](https://cloud.githubusercontent.com/assets/19661205/19503038/875abf16-95e3-11e6-90e8-325acebd6f6b.png)


**Before submitting, check that:**

 - [x] You have added (passing) tests for your code.
 - [x] You have written good* commit messages.
 - [x] You have squashed relevant commits together.
 - [x] You have ensured that RuboCop is passing.
 - [x] Your PR relates to one subject, with a clear title and
       description using complete, grammatically correct sentences.

---

If your change contains views, ensure that:

 - [x] You have included a screenshot of the new view.

---

*If you do not know what makes a good commit message, or why it
is important, please refer to these resources: [1][1], [2][2], [3][3].

[1]: https://robots.thoughtbot.com/5-useful-tips-for-a-better-commit-message
[2]: http://chris.beams.io/posts/git-commit/
[3]: https://github.com/blog/1943-how-to-write-the-perfect-pull-request

