### PR TITLE
[Fix #48][Fix #49] Allow Users edit "created_at" for donation

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -21,7 +21,7 @@
 //= require_tree .
 
 
-$(document).ready(function(){
+$(document).on('turbolinks:load', function() {
   $('.datepicker').datepicker({
     format: "dd/mm/yyyy",
     weekStart: 1,

--- a/app/controllers/donations_controller.rb
+++ b/app/controllers/donations_controller.rb
@@ -42,6 +42,6 @@ class DonationsController < ApplicationController
   end
 
   def donation_params
-    params.require(:donation).permit(:amount, :cause_id, :event_id, donor: [:identification])
+    params.require(:donation).permit(:amount, :cause_id, :event_id, :created_at, donor: [:identification])
   end
 end

--- a/app/views/donations/_edit.html.erb
+++ b/app/views/donations/_edit.html.erb
@@ -6,6 +6,10 @@
       </button>
       <h5>Edit Donation Details</h5>
       <%= form_for(@donation) do |f| %>
+        <div class="form-group">
+          <%= f.label :created_at, "Donated On", class: "control-label" %>
+          <%= f.text_field :created_at, class: "form-control datepicker", value: "#{@donation.created_at.strftime("%d/%m/%Y")}" %>
+        </div>
         <%= render "form", f: f  %>
       <% end %>
     </div>

--- a/app/views/donations/_edit.html.erb
+++ b/app/views/donations/_edit.html.erb
@@ -8,7 +8,7 @@
       <%= form_for(@donation) do |f| %>
         <div class="form-group">
           <%= f.label :created_at, "Donated On", class: "control-label" %>
-          <%= f.text_field :created_at, class: "form-control datepicker", value: "#{@donation.created_at.strftime("%d/%m/%Y")}" %>
+          <%= f.text_field :created_at, class: "form-control datepicker", value: l(@donation.created_at.to_date) %>
         </div>
         <%= render "form", f: f  %>
       <% end %>

--- a/spec/controllers/donations_controller_spec.rb
+++ b/spec/controllers/donations_controller_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe DonationsController, type: :controller do
     let(:donation) { Donation.create(amount: 100, donor: donor) }
     let(:cause) { Cause.create(shortcode: "TC", name: "Test Cause") }
     let(:event) { Event.create(name: "Test Event", start_on: "2015-10-19", end_on: "2015-10-20") }
-    let(:attr) { { amount: 200, cause_id: cause.id, event_id: event.id } }
+    let(:attr) { { amount: 200, cause_id: cause.id, event_id: event.id, created_at: "2015-11-22 00:00:00" } }
 
     before(:each) do
       put :update, id: donation.id, donation: attr
@@ -43,5 +43,6 @@ RSpec.describe DonationsController, type: :controller do
     it { expect(donation.amount).to eq attr[:amount] }
     it { expect(donation.cause_id).to eq cause.id }
     it { expect(donation.event_id).to eq event.id }
+    it { expect(donation.created_at).to eq attr[:created_at] }
   end
 end


### PR DESCRIPTION
This change allows Users to edit `created_at` attribute for `Donation`.

See screenshots below:

![screencapture-localhost-3000-donors-1-1476862321259](https://cloud.githubusercontent.com/assets/19661205/19509423/34d3bfc6-9611-11e6-9058-ffdc9783e192.png)

It also fixes an issue of datepicker working only when the page is reloaded.

---

**Before submitting, check that:**

 - [x] You have added (passing) tests for your code.
 - [x] You have written good* commit messages.
 - [x] You have squashed relevant commits together.
 - [x] You have ensured that RuboCop is passing.
 - [x] Your PR relates to one subject, with a clear title and
       description using complete, grammatically correct sentences.

---

If your change contains views, ensure that:

 - [x] You have included a screenshot of the new view.

---

*If you do not know what makes a good commit message, or why it
is important, please refer to these resources: [1][1], [2][2], [3][3].

[1]: https://robots.thoughtbot.com/5-useful-tips-for-a-better-commit-message
[2]: http://chris.beams.io/posts/git-commit/
[3]: https://github.com/blog/1943-how-to-write-the-perfect-pull-request


- Add "Donated On" form field
- Allow "created_at" attr on Donation
- Make Datepicker work with turbolinks
- Add test for editing Donation's "created_at" attr