### PR TITLE
Allow user to filter donors by cause on donors index page

### DIFF
--- a/app/controllers/donors_controller.rb
+++ b/app/controllers/donors_controller.rb
@@ -11,6 +11,7 @@ class DonorsController < ApplicationController
               else
                 Donor.all
               end
+    @donors = @donors.includes(:donations).where("donations.cause_id = ?", params[:cause_id]).references(:donations) if params[:cause_id].present?
   end
 
   def update
@@ -37,6 +38,6 @@ class DonorsController < ApplicationController
   end
 
   def donor_params
-    params.require(:donor).permit(:name, :phone_number, :email_address, :address)
+    params.require(:donor).permit(:name, :phone_number, :email_address, :address, donations: [:cause_id])
   end
 end

--- a/app/models/donor.rb
+++ b/app/models/donor.rb
@@ -5,7 +5,11 @@ class Donor < ActiveRecord::Base
 
   scope :search, -> (keyword) { where("name ILIKE ?", "%#{keyword}%") }
 
-  def total_donations
-    donations.sum(:amount).round
+  def total_donations(cause_id = nil)
+    if cause_id.present?
+      donations.where(cause_id: cause_id).sum(:amount).round
+    else
+      donations.sum(:amount).round
+    end
   end
 end

--- a/app/views/donors/index.html.erb
+++ b/app/views/donors/index.html.erb
@@ -5,44 +5,52 @@
 </div>
 <div class="table-responsive">
   <%= form_tag donors_path, method: :get do %>
-    <table class="table">
-      <thead class="thead-default">
-        <tr>
-          <td colspan="3">
-            <div class="container-fluid">
-              <div class="row">
-                <div class="col-xs-12 col-sm-6 col-md-4 offset-sm-6 offset-md-8">
-                  <div class="input-group">
-                    <%= text_field_tag :search, params[:search], placeholder: "Search by donor name ...", class: "form-control" %>
-                    <span class="input-group-btn">
-                      <%= submit_tag "Search", name: :nil, class: "btn btn-secondary" %>
-                    </span>
-                  </div>
+  <table class="table">
+    <thead class="thead-default">
+      <tr>
+        <td colspan="3">
+          <div class="container-fluid">
+            <div class="row">
+              <div class="col-xs-6 col-sm-6 col-md-4">
+                <div class="input-group">
+                  <%= text_field_tag :search, params[:search], placeholder: "Search by donor name ...", class: "form-control" %>
+                  <span class="input-group-btn">
+                    <%= submit_tag "Search", name: :nil, class: "btn btn-secondary" %>
+                  </span>
                 </div>
               </div>
+              <div class="col-xs-6 col-sm-6 col-md-4">
+                <%= select_tag :cause_id, options_from_collection_for_select(Cause.all, :id, :name), prompt: "--Filter by cause--", include_blank: "All", class: 'form-control', onchange: "myFunc(this.value)" %>
+                <script language="JavaScript" type="text/javascript">
+                   function myFunc(value) {
+                     window.location = "?cause_id="+value
+                   }
+                </script>
+              </div>
             </div>
-          </td>
-        </tr>
-        <tr>
-          <th>Name</th>
-          <th>NRIC/UEN</th>
-          <th>Total Donations</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <% if @donors.blank? && params[:search].present? %>
-            <h4>There are no donors matching <em><%= params[:search] %></em>.</h4>
-          <% end %>
-        </tr>
-        <% @donors.each do |donor| %>
-          <tr>
-            <td><%= donor.name %></td>
-            <td><%= link_to donor_path(donor) do %><%= donor.identification %><% end %></td>
-            <td>$<%= number_with_delimiter(donor.total_donations, delimiter: ",") %></td>
-          </tr>
+          </div>
+        </td>
+      </tr>
+      <tr>
+        <th>Name</th>
+        <th>NRIC/UEN</th>
+        <th>Total Donations</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <% if @donors.blank? && params[:search].present? %>
+        <h4>There are no donors matching <em><%= params[:search] %></em>.</h4>
         <% end %>
-      </tbody>
-    </table>
+      </tr>
+      <% @donors.each do |donor| %>
+      <tr>
+        <td><%= donor.name %></td>
+        <td><%= link_to donor_path(donor) do %><%= donor.identification %><% end %></td>
+        <td>$<%= number_with_delimiter(donor.total_donations(params[:cause_id]), delimiter: ",") %></td>
+      </tr>
+      <% end %>
+    </tbody>
+  </table>
   <% end %>
 </div>

--- a/app/views/donors/show.html.erb
+++ b/app/views/donors/show.html.erb
@@ -10,7 +10,7 @@
 
 <div>
   <h2>Total Amount Donated</h2>
-  <h1>$<%= number_with_delimiter(@donor.total_donations, delimiter: ",") %></h1>
+  <h1>$<%= number_with_delimiter(@donor.total_donations(params[:cause_id]), delimiter: ",") %></h1>
   <h5>Donor since <%= @donor.created_at.strftime("%d %b %Y") %> (<%= time_ago_in_words(@donor.created_at) %>)</h5>
 </div>
 

--- a/db/seeds/causes.rb
+++ b/db/seeds/causes.rb
@@ -1,8 +1,14 @@
 puts "Seeding Causes ..."
 
+causes = [
+  shortcode: "HH",
+  name: "Halfway House"
+],
+[
+  shortcode: "GE",
+  name: "General"
+]
+
 unless Cause.any?
-  Cause.create!(
-    shortcode: "HH",
-    name: "Halfway House"
-  )
+  Cause.create!(causes)
 end

--- a/spec/factories/causes.rb
+++ b/spec/factories/causes.rb
@@ -1,7 +1,11 @@
 FactoryGirl.define do
+  sequence :name do |n|
+    "Cause #{n}"
+  end
+
   factory :cause do
     shortcode "HH"
-    name "Halfway House"
+    name
 
     trait :invalid do
       name nil

--- a/spec/factories/donations.rb
+++ b/spec/factories/donations.rb
@@ -7,5 +7,9 @@ FactoryGirl.define do
     trait :invalid do
       amount nil
     end
+
+    factory :donation_with_cause do
+      cause
+    end
   end
 end

--- a/spec/factories/donors.rb
+++ b/spec/factories/donors.rb
@@ -13,6 +13,7 @@ FactoryGirl.define do
     factory :donor_with_donations do
       after(:create) do |donor|
         create_list(:donation, 2, donor: donor)
+        create_list(:donation_with_cause, 2, donor: donor)
       end
     end
   end

--- a/spec/models/donor_spec.rb
+++ b/spec/models/donor_spec.rb
@@ -11,7 +11,8 @@ RSpec.describe Donor, type: :model do
   describe "#total_donations" do
     let(:donor) { create(:donor_with_donations) }
 
-    it { expect(donor.total_donations).to eq(200) }
+    it { expect(donor.total_donations).to eq(400) }
+    it { expect(donor.total_donations(1)).to eq(0) }
   end
 
   describe ".search" do


### PR DESCRIPTION
This change allows a user to filter donors by cause on the donors index page. The total donation amount will also pertain only to filtered donations.

Screenshot of donors index page:
![screen shot 2016-10-19 at 3 17 06 pm](https://cloud.githubusercontent.com/assets/16523290/19509593/14d88b60-9612-11e6-8ca8-661aa86eed63.png)

---

**Before submitting, check that:**

 - [x] You have added (passing) tests for your code.
 - [x] You have written good* commit messages.
 - [x] You have squashed relevant commits together.
 - [x] You have ensured that RuboCop is passing.
 - [x] Your PR relates to one subject, with a clear title and
       description using complete, grammatically correct sentences.

---

If your change contains views, ensure that:

 - [x] You have included a screenshot of the new view.

---

*If you do not know what makes a good commit message, or why it
is important, please refer to these resources: [1][1], [2][2], [3][3].

[1]: https://robots.thoughtbot.com/5-useful-tips-for-a-better-commit-message
[2]: http://chris.beams.io/posts/git-commit/
[3]: https://github.com/blog/1943-how-to-write-the-perfect-pull-request

