### PR TITLE
Add rudimentary styling to user sign in page

### DIFF
--- a/app/views/sessions/_form.html.erb
+++ b/app/views/sessions/_form.html.erb
@@ -1,0 +1,23 @@
+<%= form_for :session, url: session_path do |form| %>
+  <div class="form-group">
+    <div class="input-group">
+      <span class="input-group-addon" id="basic-addon1">
+        <%= fa_icon "envelope", class: "fa-fw" %>
+      </span>
+      <%= form.text_field :email, type: "email", class: "form-control" %>
+    </div>
+  </div>
+
+  <div class="form-group">
+    <div class="input-group">
+      <span class="input-group-addon" id="basic-addon1">
+        <%= fa_icon "lock", class: "fa-fw" %>
+      </span>
+      <%= form.password_field :password, class: "form-control" %>
+    </div>
+  </div>
+
+  <div class="form-group">
+    <%= form.submit class: "form-control btn btn-primary" %>
+  </div>
+<% end %>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,0 +1,9 @@
+<div class="container-fluid">
+  <div class="row">
+    <div class="col-sm-4 offset-sm-4">
+      <div id="clearance" class="sign-in">
+        <h2 class="text-center"><%= t(".title") %></h2>
+        <%= render partial: '/sessions/form' %>
+      </div>
+    </div>
+  </div>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -1,9 +1,0 @@
-<div class="input-group">
-  <span class="input-group-addon" id="basic-addon1">E-mail</span>
-  <input type="text" class="form-control" placeholder="Username" aria-describedby="basic-addon1">
-</div>
-
-<div class="input-group">
-  <span class="input-group-addon" id="basic-addon1">Password</span>
-  <input type="text" class="form-control" placeholder="Username" aria-describedby="basic-addon1">
-</div>

--- a/spec/models/donor_spec.rb
+++ b/spec/models/donor_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Donor, type: :model do
     let(:donor) { create(:donor_with_donations) }
 
     it { expect(donor.total_donations).to eq(400) }
-    it { expect(donor.total_donations(1)).to eq(0) }
+    it { expect(donor.total_donations(-1)).to eq(0) }
   end
 
   describe ".search" do


### PR DESCRIPTION
This change adds some Bootstrap classes to the sign in page, which will serve as a basis for styling it later on.

<img width="401" alt="screen shot 2016-10-22 at 16 25 05" src="https://cloud.githubusercontent.com/assets/5259935/19618119/84e594d4-9874-11e6-88f1-3815ae708aea.png">

---

**Before submitting, check that:**

 - [X] You have written good* commit messages.
 - [X] You have squashed relevant commits together.
 - [X] You have ensured that RuboCop is passing.
 - [X] Your PR relates to one subject, with a clear title and
       description using complete, grammatically correct sentences.

---

If your change contains views, ensure that:

 - [X] You have included a screenshot of the new view.

---

*If you do not know what makes a good commit message, or why it
is important, please refer to these resources: [1][1], [2][2], [3][3].

[1]: https://robots.thoughtbot.com/5-useful-tips-for-a-better-commit-message
[2]: http://chris.beams.io/posts/git-commit/
[3]: https://github.com/blog/1943-how-to-write-the-perfect-pull-request