### PR TITLE
Prevent `bootstrap-datepicker` from loading all locales

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -15,7 +15,8 @@
 //= require jquery_ujs
 //= require turbolinks
 //= require tether
-//= require bootstrap-datepicker
+//= require bootstrap-datepicker/core
+//= require bootstrap-datepicker/locales/bootstrap-datepicker.en-GB.js
 //= require bootstrap-sprockets
 //= require_tree .
 
@@ -28,5 +29,3 @@ $(document).ready(function(){
     todayHighlight: true
   });
 });
-
-


### PR DESCRIPTION
This gem would load all its locales, resulting in a lot of unneeded files being loaded.

This change fixes that, and loads only English.

---

**Before submitting, check that:**

 - [X] You have written good* commit messages.
 - [X] You have squashed relevant commits together.
 - [X] You have ensured that RuboCop is passing.
 - [X] Your PR relates to one subject, with a clear title and
       description using complete, grammatically correct sentences.

---

*If you do not know what makes a good commit message, or why it
is important, please refer to these resources: [1][1], [2][2], [3][3].

[1]: https://robots.thoughtbot.com/5-useful-tips-for-a-better-commit-message
[2]: http://chris.beams.io/posts/git-commit/
[3]: https://github.com/blog/1943-how-to-write-the-perfect-pull-request
