### PR TITLE
[Fix #55] Allow Users to see the filter value in the select box after filtering Donors by Cause on donors/index page

### DIFF
--- a/app/views/donors/index.html.erb
+++ b/app/views/donors/index.html.erb
@@ -20,7 +20,7 @@
                 </div>
               </div>
               <div class="col-xs-6 col-sm-6 col-md-4">
-                <%= select_tag :cause_id, options_from_collection_for_select(Cause.all, :id, :name), prompt: "--Filter by cause--", include_blank: "All", class: 'form-control', onchange: "myFunc(this.value)" %>
+                <%= select_tag :cause_id, options_from_collection_for_select(Cause.all, :id, :name, params[:cause_id]), prompt: "--Filter by cause--", include_blank: "All", class: 'form-control', onchange: "myFunc(this.value)" %>
                 <script language="JavaScript" type="text/javascript">
                    function myFunc(value) {
                      window.location = "?cause_id="+value


### PR DESCRIPTION
This change makes the filter value stick in the select box after filtering `Donors` by `Cause` on `donors/index` page.

---

See the screenshot below:

![screencapture-localhost-3000-donors-1477279428105](https://cloud.githubusercontent.com/assets/19661205/19632756/585d4b14-99dc-11e6-8498-1b014d5167ce.png)

---

**Before submitting, check that:**

 - [ ] You have added (passing) tests for your code.
 - [x] You have written good* commit messages.
 - [x] You have squashed relevant commits together.
 - [x] You have ensured that RuboCop is passing.
 - [x] Your PR relates to one subject, with a clear title and
       description using complete, grammatically correct sentences.

--- 

If your change contains views, ensure that:

 - [x] You have included a screenshot of the new view.

---

*If you do not know what makes a good commit message, or why it
is important, please refer to these resources: [1][1], [2][2], [3][3].

[1]: https://robots.thoughtbot.com/5-useful-tips-for-a-better-commit-message
[2]: http://chris.beams.io/posts/git-commit/
[3]: https://github.com/blog/1943-how-to-write-the-perfect-pull-request


