### PR TITLE
Allow user to sort donors in donors/show page

### DIFF
--- a/app/assets/javascripts/index.js
+++ b/app/assets/javascripts/index.js
@@ -1,0 +1,3 @@
+function cause_toggle(value) {
+  window.location = "?cause_id="+value
+}

--- a/app/controllers/donors_controller.rb
+++ b/app/controllers/donors_controller.rb
@@ -6,12 +6,13 @@ class DonorsController < ApplicationController
 
   # GET /donors
   def index
-    @donors = if params[:search]
-                Donor.search(params[:search])
+    @donors = if params[:total_donations] == "asc"
+                searched_donors.sort_by(&:total_donations)
+              elsif params[:total_donations] == "desc"
+                searched_donors.sort_by(&:total_donations).reverse
               else
-                Donor.all
+                searched_donors
               end
-    @donors = @donors.includes(:donations).where("donations.cause_id = ?", params[:cause_id]).references(:donations) if params[:cause_id].present?
   end
 
   def update
@@ -38,6 +39,22 @@ class DonorsController < ApplicationController
   end
 
   def donor_params
-    params.require(:donor).permit(:name, :phone_number, :email_address, :address, donations: [:cause_id])
+    params.require(:donor).permit(:name, :phone_number, :email_address, :address)
+  end
+
+  def filtered_donors
+    if params[:cause_id].present?
+      Cause.find(params[:cause_id]).donors
+    else
+      Donor.all
+    end
+  end
+
+  def searched_donors
+    if params[:search]
+      filtered_donors.search(params[:search])
+    else
+      filtered_donors
+    end
   end
 end

--- a/app/models/cause.rb
+++ b/app/models/cause.rb
@@ -1,5 +1,6 @@
 class Cause < ActiveRecord::Base
   has_many :donations, inverse_of: :cause
+  has_many :donors, -> { unscope(:order).uniq }, through: :donations
 
   validates :shortcode, presence: true
   validates :name, presence: true, uniqueness: true

--- a/app/views/donors/index.html.slim
+++ b/app/views/donors/index.html.slim
@@ -16,15 +16,18 @@
                     span.input-group-btn
                       = submit_tag "Search", name: :nil, class: "btn btn-secondary"
                 .col-xs-6.col-sm-6.col-md-4
-                  = select_tag :cause_id, options_from_collection_for_select(Cause.all, :id, :name, params[:cause_id]), prompt: "Filter by cause:", include_blank: "All", class: 'form-control', onchange: "myFunc(this.value)"
-                  javascript:
-                     function myFunc(value) {
-                       window.location = "?cause_id=" + value
-                     }
+                  = select_tag :cause_id, options_from_collection_for_select(Cause.all, :id, :name, params[:cause_id]), prompt: "Filter by cause:", include_blank: "All", class: 'form-control', onchange: "cause_toggle(this.value)"
         tr
           th Name
           th NRIC/UEN
-          th Total Donations
+          th 
+            | Total Donations
+            .btn-group.btn-group-sm
+              button.btn.btn-secondary data-toggle="dropdown" type="button" 
+                i.fa.fa-caret-down.fa-lg
+              ul.dropdown-menu role="menu" 
+                li= link_to "Lowest first", params.merge(total_donations: "asc")
+                li= link_to "Highest first", params.merge(total_donations: "desc")
       tbody
         tr
           - if @donors.blank? && params[:search].present?


### PR DESCRIPTION
This change allows a user to sort donors in the donors/show page by total donation amount.
- It allows sorting within the cause and search fields selected.
- It also enables searching within the cause field selected.

Screenshot of donors/show page:
![screen shot 2016-10-27 at 1 51 01 am](https://cloud.githubusercontent.com/assets/16523290/19737890/e21dbd5e-9be7-11e6-9e2a-8a60adef06ae.png)
---

**Before submitting, check that:**
- [ ] You have added (passing) tests for your code.
- [x] You have written good\* commit messages.
- [ ] You have squashed relevant commits together.
- [x] You have ensured that RuboCop is passing.
- [x] Your PR relates to one subject, with a clear title and
     description using complete, grammatically correct sentences.
---

*If you do not know what makes a good commit message, or why it
is important, please refer to these resources: [1](https://robots.thoughtbot.com/5-useful-tips-for-a-better-commit-message), [2](http://chris.beams.io/posts/git-commit/), [3](https://github.com/blog/1943-how-to-write-the-perfect-pull-request).
