### PR TITLE
Allow Users to see total donations for current year on the Dashboard page

### DIFF
--- a/app/controllers/donations_controller.rb
+++ b/app/controllers/donations_controller.rb
@@ -11,6 +11,10 @@ class DonationsController < ApplicationController
     end
   end
 
+  def index
+    @donations = Donation.all
+  end
+
   # PATCH /update
   def update
     @donation = find_donation(params[:id])

--- a/app/models/donation.rb
+++ b/app/models/donation.rb
@@ -9,4 +9,6 @@ class Donation < ActiveRecord::Base
   validates :amount, presence: true, numericality: { greater_than: 0 }
 
   scope :search, -> (keyword) { joins(:donor).where("name ILIKE ?", "%#{keyword}%") }
+
+  scope :donations_per_year, -> (year) { where("EXTRACT(YEAR FROM created_at) = ?", year) }
 end

--- a/app/views/donations/index.html.slim
+++ b/app/views/donations/index.html.slim
@@ -1,0 +1,7 @@
+.card.card-inverse.card-info.text-xs-center
+  .card.card-inverse.card-info.text-xs-center
+    .card-block
+      h1 Total Donations for #{Date.today.year}
+      h1 $#{@donations.donations_per_year(Date.current.year).sum(:amount).round}
+
+

--- a/app/views/layouts/_navbar.html.slim
+++ b/app/views/layouts/_navbar.html.slim
@@ -1,8 +1,9 @@
 .navbar.navbar-light.navbar-static-top
   .collapse.navbar-toggleable-xs#exCollapsingNavbar2
+    = link_to "HCSA Admin", donations_path, class: "navbar-brand"
     ul.nav.navbar-nav
-      li.nav-item = link_to "Donors", donors_path
-      li.nav-item = link_to "Events", events_path
+      li.nav-item = link_to "Donors", donors_path, class: "nav-link"
+      li.nav-item = link_to "Events", events_path, class: "nav-link"
       li.nav-item.pull-sm-right
         .btn-group
           button.btn.btn-default.dropdown-toggle type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  resources :donations, only: [:create, :update, :edit]
+  resources :donations, only: [:create, :index, :update, :edit]
   resources :donors, only: [:index, :show, :update, :edit]
   resources :events, only: [:create, :index, :show]
 end

--- a/spec/factories/donations.rb
+++ b/spec/factories/donations.rb
@@ -4,6 +4,8 @@ FactoryGirl.define do
 
     amount 100
 
+    created_at Time.zone.today
+
     trait :invalid do
       amount nil
     end

--- a/spec/factories/donors.rb
+++ b/spec/factories/donors.rb
@@ -5,6 +5,9 @@ FactoryGirl.define do
 
   factory :donor do
     identification
+    trait name do
+      name "Test"
+    end
 
     trait :invalid do
       identification nil

--- a/spec/models/donation_spec.rb
+++ b/spec/models/donation_spec.rb
@@ -9,16 +9,22 @@ RSpec.describe Donation, type: :model do
   it { is_expected.to validate_numericality_of(:amount).is_greater_than(0) }
 
   describe ".search" do
-    let(:smithie_black) { create(:donor, name: "Smithie Black") }
-    let(:bob_smith_white) { create(:donor, name: "Bob Smith-White") }
-    let(:john_smith) { create(:donor, name: "John Smith") }
-    let(:carl_grey) { create(:donor, name: "Carl Grey") }
+    before do
+      @match_behinning = create(:donation, donor: create(:donor, name: "Smithie Black"))
+      @match_middle = create(:donation, donor: create(:donor, name: "Bob Smith White"))
+      @match_end = create(:donation, donor: create(:donor, name: "John Smith"))
+      @no_match = create(:donation, donor: create(:donor, name: "Carl Grey"))
+    end
 
-    let(:match_beginning) { create(:donation, amount: 100, donor: smithie_black) }
-    let(:match_middle) { create(:donation, amount: 100, donor: bob_smith_white) }
-    let(:match_end) { create(:donation, amount: 100, donor: john_smith) }
-    let(:no_match) { create(:donation, amount: 100, donor: carl_grey) }
+    it { expect(described_class.search("smith")).to match_array [@match_behinning, @match_middle, @match_end] }
+  end
 
-    it { expect(described_class.search("smith")).to contain_exactly(match_beginning, match_middle, match_end) }
+  describe ".donations_per_year" do
+    before do
+      create_list(:donation, 2)
+      create(:donation, created_at: 1.year.ago)
+    end
+
+    it { expect(described_class.donations_per_year(Date.current.year).sum(:amount).round).to eq(200) }
   end
 end

--- a/spec/models/donor_spec.rb
+++ b/spec/models/donor_spec.rb
@@ -16,13 +16,15 @@ RSpec.describe Donor, type: :model do
   end
 
   describe ".search" do
-    let(:match_beginning) { create(:donor, name: "Smithie Black") }
-    let(:match_middle) { create(:donor, name: "Bob Smith-White") }
-    let(:match_end) { create(:donor, name: "John Smith") }
-    let(:no_match) { create(:donor, name: "Carl Grey") }
-    let(:match_identification) { create(:donor, identification: "G1234567M") }
+    before do
+      @match_beginning = create(:donor, name: "Smithie Black")
+      @match_middle = create(:donor, name: "Bob Smith-White")
+      @match_end = create(:donor, name: "John Smith")
+      @no_match = create(:donor, name: "Carl Grey")
+      @match_identification = create(:donor, identification: "B777888A")
+    end
 
-    it { expect(described_class.search("smith")).to contain_exactly(match_beginning, match_middle, match_end) }
-    it { expect(described_class.search("g123")).to contain_exactly(match_identification) }
+    it { expect(described_class.search("smith")).to contain_exactly(@match_beginning, @match_middle, @match_end) }
+    it { expect(described_class.search("b777")).to contain_exactly(@match_identification) }
   end
 end

--- a/spec/routing/donations_routing_spec.rb
+++ b/spec/routing/donations_routing_spec.rb
@@ -4,4 +4,5 @@ RSpec.describe DonationsController, type: :routing do
   it { expect(post: "donations").to route_to("donations#create") }
   it { expect(put: "donations/1").to route_to(controller: "donations", action: "update", id: "1") }
   it { expect(get: "donations/1/edit").to route_to(controller: "donations", action: "edit", id: "1") }
+  it { expect(get: "donations").to route_to(controller: "donations", action: "index") }
 end


### PR DESCRIPTION
This change creates a Dashboard page which can be accessed by clicking on "HCSA Admin" link in the `navbar`. It also lets Users see the total amount donated for the current year.

See the screenshots below:

![screencapture-localhost-3000-donations-1477536828582](https://cloud.githubusercontent.com/assets/19661205/19752960/afc64dd4-9c33-11e6-85d7-e62ff59edd03.png)


---

**Before submitting, check that:**

 - [x] You have added (passing) tests for your code.
 - [x] You have written good* commit messages.
 - [x] You have squashed relevant commits together.
 - [x] You have ensured that RuboCop is passing.
 - [x] Your PR relates to one subject, with a clear title and
       description using complete, grammatically correct sentences.

---


If your change contains views, ensure that:

 - [x] You have included a screenshot of the new view.

---

*If you do not know what makes a good commit message, or why it
is important, please refer to these resources: [1][1], [2][2], [3][3].

[1]: https://robots.thoughtbot.com/5-useful-tips-for-a-better-commit-message
[2]: http://chris.beams.io/posts/git-commit/
[3]: https://github.com/blog/1943-how-to-write-the-perfect-pull-request


- Add link on navbar to dashboard
- Route dashboard to donations/index
- Create donations_for_current_year for dashboard