### PR TITLE
Allow user to sort events on events/index

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -16,10 +16,16 @@ class EventsController < ApplicationController
   end
 
   def index
-    @events = if params[:search]
-                Event.search(params[:search])
+    @events = if sort_column == "start_on"
+                searched_events.order(sort_column + " " + sort_direction)
+              elsif sort_column == "total_donations"
+                if sort_direction == "ASC"
+                  searched_events.sort_by(&:total_donations)
+                else
+                  searched_events.sort_by(&:total_donations).reverse
+                end
               else
-                Event.all
+                searched_events
               end
     respond_to do |format|
       format.html
@@ -73,4 +79,25 @@ class EventsController < ApplicationController
   def find_event(id)
     Event.find(id)
   end
+
+  def sort_column
+    params[:sort] || "start_on"
+  end
+
+  def sort_direction
+    params[:direction] || "DESC"
+  end
+
+  def searched_events
+    if params[:search]
+      Event.search(params[:search])
+    else
+      Event.all
+    end
+  end
+
+  def safe_params(unsafe = {})
+    params.merge(unsafe).merge(only_path: true)
+  end
+  helper_method :safe_params
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,6 +1,4 @@
 class Event < ActiveRecord::Base
-  default_scope { order(created_at: :desc) }
-
   has_many :donations, inverse_of: :event
 
   validates :start_on, presence: true

--- a/app/views/events/_index.html.slim
+++ b/app/views/events/_index.html.slim
@@ -17,9 +17,23 @@
                       = submit_tag "Search", name: :nil, class: "btn btn-secondary"
         tr.thead-default
           th Name
-          th Date
-          th Total Donations
-          th
+          th 
+            | Date
+            .btn-group.btn-group-sm
+              button.btn.btn-secondary data-toggle="dropdown" type="button"
+                i.fa.fa-caret-down.fa-lg
+              ul.dropdown-menu role="menu"
+                li= link_to "Latest event first", safe_params(sort: "start_on", direction: "DESC")
+                li= link_to "Earliest event first", safe_params(sort: "start_on", direction: "ASC")
+          th 
+            | Total Donations
+            .btn-group.btn-group-sm
+              button.btn.btn-secondary data-toggle="dropdown" type="button"
+                i.fa.fa-caret-down.fa-lg
+              ul.dropdown-menu role="menu"
+                li= link_to "Lowest first", safe_params(sort: "total_donations", direction: "ASC")
+                li= link_to "Highest first", safe_params(sort: "total_donations", direction: "DESC")
+
       tbody.events-index
         tr
           - if @events.blank?
@@ -39,4 +53,3 @@
                 i.fa.fa-pencil.fa-lg
 
 .modal.fade#editEvent role="dialog" aria-labelledby="myModalLabel" aria-hidden="true"
-


### PR DESCRIPTION
This change allows a user to sort events on the events/index by total donations or date of event. 

Note: Rubocop does not pass because of a bloated controller. This can be fixed by creating a Ruby object.

Screenshot:
![screen shot 2016-10-30 at 3 15 33 am](https://cloud.githubusercontent.com/assets/16523290/19832188/81674cea-9e4f-11e6-9b80-a77835d54199.png)
---

**Before submitting, check that:**
- [ ] You have added (passing) tests for your code.
- [x] You have written good\* commit messages.
- [ ] You have squashed relevant commits together.
- [ ] You have ensured that RuboCop is passing.
- [x] Your PR relates to one subject, with a clear title and
     description using complete, grammatically correct sentences.
---

If your change contains views, ensure that:
- [x] You have included a screenshot of the new view.
