### PR TITLE
Allow users to edit events

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,13 +1,18 @@
 class EventsController < ApplicationController
   before_action :prepare_modal_event
 
-  def show
-    @event = find_event(params[:id])
-    @donations = if params[:search]
-                   @event.donations.search(params[:search])
-                 else
-                   @event.donations
-                 end
+  def create
+    @event = Event.new(event_params)
+    @events = Event.all
+
+    respond_to do |format|
+      if @event.save
+        format.html { redirect_to events_path }
+        format.js { flash.now[:notice] = "Event was successfully created." }
+      else
+        format.js
+      end
+    end
   end
 
   def index
@@ -22,17 +27,36 @@ class EventsController < ApplicationController
     end
   end
 
-  def create
-    @event = Event.new(event_params)
+  def show
+    @event = find_event(params[:id])
+    @donations = if params[:search]
+                   @event.donations.search(params[:search])
+                 else
+                   @event.donations
+                 end
+  end
+
+  # PATCH /update
+  def update
+    @event = find_event(params[:id])
     @events = Event.all
 
     respond_to do |format|
-      if @event.save
+      if @event.update(event_params)
         format.html { redirect_to events_path }
-        format.js { flash.now[:notice] = "Event was successfully created." }
+        format.js { flash.now[:notice] = "Event was successfully updated." }
       else
         format.js
       end
+    end
+  end
+
+  # GET /edit
+  def edit
+    @event = find_event(params[:id])
+
+    respond_to do |format|
+      format.js
     end
   end
 

--- a/app/views/donations/_new.html.slim
+++ b/app/views/donations/_new.html.slim
@@ -4,7 +4,7 @@
       .modal-body
         button.close type="button" data-dismiss="modal" aria-label="Close"
           span aria-hidden="true" &times;
-        h5 Donation Details
+        h5.modal-title Donation Details
         = form_for(@modal_donation) do |f|
           = f.fields_for :donor, @modal_donation.donor do |donor|
             .form-group

--- a/app/views/events/_edit.html.slim
+++ b/app/views/events/_edit.html.slim
@@ -1,0 +1,8 @@
+.modal-dialog.modal-sm role="document"
+  .modal-content
+    .modal-body
+      button.close type="button" data-dismiss="modal" aria-label="Close"
+        span aria-hidden="true" &times;
+      h5 Edit Event Details
+      = form_for(@event, remote: true) do |f|
+        = render "form", f: f

--- a/app/views/events/_form.html.slim
+++ b/app/views/events/_form.html.slim
@@ -1,0 +1,12 @@
+.errors
+.form-group
+  = f.label :name, "Event Name", class: "control-label"
+  = f.text_field :name, class: "form-control"
+.form-group
+  = f.label :start_on, "Start Date", class: "control-label"
+  = f.text_field :start_on, class: "form-control datepicker", value:(@event.present? ? l(@event.start_on) : "")
+.form-group
+  = f.label :end_on, "End Date", class: "control-label"
+  = f.text_field :end_on, class: "form-control datepicker", value:(@event.present? ? l(@event.end_on) : "")
+.actions
+  = f.submit class: "btn btn-primary form-control"

--- a/app/views/events/_index.html.slim
+++ b/app/views/events/_index.html.slim
@@ -19,6 +19,7 @@
           th Name
           th Date
           th Total Donations
+          th
       tbody.events-index
         tr
           - if @events.blank?
@@ -26,5 +27,16 @@
         - @events.each do |event|
           tr
             td = link_to event.name, event_path(event)
-            td #{l event.start_on, format: :short} - #{l event.end_on, format: :default}
+            - if event.start_on == event.end_on
+              td #{l event.start_on, format: :default}
+            - elsif event.start_on.year != event.end_on.year
+              td #{l event.start_on, format: :default} - #{l event.end_on, format: :default}
+            - else
+              td #{l event.start_on, format: :short} - #{l event.end_on, format: :default}
             td $#{number_with_delimiter(event.total_donations, delimiter: ",")}
+            td
+              = link_to edit_event_path(event), remote: true do
+                i.fa.fa-pencil.fa-lg
+
+.modal.fade#editEvent role="dialog" aria-labelledby="myModalLabel" aria-hidden="true"
+

--- a/app/views/events/_new.html.slim
+++ b/app/views/events/_new.html.slim
@@ -4,17 +4,6 @@
       .modal-body
         button.close type="button" data-dismiss="modal" aria-label="Close"
           span aria-hidden="true" &times;
-        h4.modal-title Event Details
+        h5.modal-title Event Details
         = form_for @modal_event, remote: true do |f|
-          .errors
-          .form-group
-            = f.label :name, "Event Name", class: "control-label"
-            = f.text_field :name, class: "form-control"
-          .form-group
-            = f.label :start_on, "Start Date", class: "control-label"
-            = f.text_field :start_on, class: "form-control datepicker"
-          .form-group
-            = f.label :end_on, "End Date", class: "control-label"
-            = f.text_field :end_on, class: "form-control datepicker"
-          .actions
-            = f.submit class: "btn btn-primary form-control"
+          = render "form", f: f

--- a/app/views/events/edit.js.erb
+++ b/app/views/events/edit.js.erb
@@ -1,0 +1,3 @@
+$("#editEvent").empty()
+$("#editEvent").append("<%= j render partial: 'events/edit' %>");
+$("#editEvent").modal("show");

--- a/app/views/events/update.js.erb
+++ b/app/views/events/update.js.erb
@@ -1,0 +1,13 @@
+$("div.errors").html("")
+<% if @event.errors.any? %>
+  <% @event.errors.full_messages.each do |message| %>
+    $("div.errors").append($("<div />").html("<%= message.html_safe %>").addClass("alert alert-danger"))
+  <% end %>
+<% else %>
+  $("#editEvent").modal("hide")
+  $('body').removeClass('modal-open');
+  $('.modal-backdrop').remove();
+  $(".table-responsive").html("<%= escape_javascript(render 'index') %>")
+<% end %>
+
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   resources :donations, only: [:create, :index, :update, :edit]
   resources :donors, only: [:index, :show, :update, :edit]
-  resources :events, only: [:create, :index, :show]
+  resources :events, only: [:create, :index, :show, :update, :edit]
 end


### PR DESCRIPTION
This change allows Users to edit an event on `events/index` page by clicking on a "pencil" icon.

This change also:

- [Fix #65] Changes date display format on `events/index`
- Adds notifications to `events/edit` modal if invalid input is entered

---

See the screenshots below:

![screencapture-localhost-3000-events-1477809434818](https://cloud.githubusercontent.com/assets/19661205/19834895/9daaf528-9eae-11e6-97cb-29180d426e57.png)

![screencapture-localhost-3000-events-1477809471940](https://cloud.githubusercontent.com/assets/19661205/19834897/a49a47ee-9eae-11e6-92fc-7635b1fb025d.png)

![screencapture-localhost-3000-events-1477809488628](https://cloud.githubusercontent.com/assets/19661205/19834899/ac464e5c-9eae-11e6-9e25-63510c6e0db9.png)

![screen shot 2016-10-30 at 2 40 52 pm](https://cloud.githubusercontent.com/assets/19661205/19834906/eab44c52-9eae-11e6-9cab-4a30c47f905e.png)



---

**Before submitting, check that:**

 - [x] You have added (passing) tests for your code.
 - [x] You have written good* commit messages.
 - [ ] You have squashed relevant commits together.
 - [x] You have ensured that RuboCop is passing.
 - [x] Your PR relates to one subject, with a clear title and
       description using complete, grammatically correct sentences.

---

If your change contains views, ensure that:

 - [x] You have included a screenshot of the new view.

---

*If you do not know what makes a good commit message, or why it
is important, please refer to these resources: [1][1], [2][2], [3][3].

[1]: https://robots.thoughtbot.com/5-useful-tips-for-a-better-commit-message
[2]: http://chris.beams.io/posts/git-commit/
[3]: https://github.com/blog/1943-how-to-write-the-perfect-pull-request

