### PR TITLE
[Fix #67] Add link to event from donor/show page

### DIFF
--- a/app/views/donors/show.html.slim
+++ b/app/views/donors/show.html.slim
@@ -25,7 +25,7 @@ div
           td = l donation.created_at.to_date, format: donation.created_at.year == Date.today.year ? :short : :default
           td $#{donation.amount.to_i}
           td = donation.cause&.name
-          td = donation.event&.name
+          td = link_to donation.event&.name, event_path(donation.event)
           td
             = link_to edit_donation_path(donation), remote: true do
               i.fa.fa-pencil.fa-lg


### PR DESCRIPTION
Allow user to link to event from donor/show page

Screenshot:
![screen shot 2016-10-30 at 5 59 19 pm](https://cloud.githubusercontent.com/assets/16523290/19835785/c7de3078-9eca-11e6-9a6a-f512337435db.png)

---

**Before submitting, check that:**

 - [ ] You have added (passing) tests for your code.
 - [x] You have written good* commit messages.
 - [x] You have squashed relevant commits together.
 - [x] You have ensured that RuboCop is passing.
 - [x] Your PR relates to one subject, with a clear title and
       description using complete, grammatically correct sentences.

---

If your change contains views, ensure that:

 - [x] You have included a screenshot of the new view.

---

*If you do not know what makes a good commit message, or why it
is important, please refer to these resources: [1][1], [2][2], [3][3].

[1]: https://robots.thoughtbot.com/5-useful-tips-for-a-better-commit-message
[2]: http://chris.beams.io/posts/git-commit/
[3]: https://github.com/blog/1943-how-to-write-the-perfect-pull-request


