### PR TITLE
[Fix #66] Display alerts when creating or editing a Donation

### DIFF
--- a/app/controllers/donations_controller.rb
+++ b/app/controllers/donations_controller.rb
@@ -4,10 +4,14 @@ class DonationsController < ApplicationController
     donor = find_or_build_donor(donation_params.delete(:donor))
     @donation = Donation.new(donation_params.merge(donor: donor))
 
-    if @donation.save
-      redirect_to donor_path(@donation.donor), notice: "Donation was successfully created."
-    else
-      redirect_to :back, error: @donation.errors.full_messages.to_sentence
+    respond_to do |format|
+      if @donation.save
+        format.js {}
+        format.html {}
+        redirect_to donor_path(@donation.donor), notice: "Donation was successfully created."
+      else
+        format.js
+      end
     end
   end
 
@@ -19,10 +23,14 @@ class DonationsController < ApplicationController
   def update
     @donation = find_donation(params[:id])
 
-    if @donation.update(donation_params)
-      redirect_to donor_path(@donation.donor), notice: "Donation was successfully updated."
-    else
-      redirect_to donor_path(@donation.donor), error: "Failed to update donation."
+    respond_to do |format|
+      if @donation.update(donation_params)
+        format.js {}
+        format.html {}
+        redirect_to donor_path(@donation.donor), notice: "Donation was successfully updated."
+      else
+        format.js
+      end
     end
   end
 

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -7,8 +7,8 @@ class EventsController < ApplicationController
 
     respond_to do |format|
       if @event.save
-        format.html { redirect_to events_path }
         format.js { flash.now[:notice] = "Event was successfully created." }
+        format.html { redirect_to events_path }
       else
         format.js
       end

--- a/app/models/donation.rb
+++ b/app/models/donation.rb
@@ -6,6 +6,7 @@ class Donation < ActiveRecord::Base
   belongs_to :event, inverse_of: :donations
 
   validates :donor, presence: true
+  validates_associated :donor
   validates :amount, presence: true, numericality: { greater_than: 0 }
 
   scope :search, -> (keyword) { joins(:donor).where("name ILIKE ?", "%#{keyword}%") }

--- a/app/views/donations/_edit.html.slim
+++ b/app/views/donations/_edit.html.slim
@@ -4,7 +4,7 @@
       button.close type="button" data-dismiss="modal" aria-label="Close"
         span aria-hidden="true" &times;
       h5 Edit Donation Details
-      = form_for(@donation) do |f|
+      = form_for(@donation, remote: true) do |f|
         .form-group
           = f.label :created_at, "Donated On", class: "control-label"
           = f.text_field :created_at, class: "form-control datepicker", value: l(@donation.created_at.to_date)

--- a/app/views/donations/_form.html.slim
+++ b/app/views/donations/_form.html.slim
@@ -1,3 +1,4 @@
+.errors
 .form-group
   = f.label :amount, class: "control-label"
   = f.text_field :amount, class: "form-control"

--- a/app/views/donations/_new.html.slim
+++ b/app/views/donations/_new.html.slim
@@ -5,7 +5,7 @@
         button.close type="button" data-dismiss="modal" aria-label="Close"
           span aria-hidden="true" &times;
         h5.modal-title Donation Details
-        = form_for(@modal_donation) do |f|
+        = form_for(@modal_donation, remote: true) do |f|
           = f.fields_for :donor, @modal_donation.donor do |donor|
             .form-group
               label.form-control-label for="donorDocs" Donor NRIC/UEN

--- a/app/views/donations/create.js.erb
+++ b/app/views/donations/create.js.erb
@@ -1,0 +1,8 @@
+$("div.errors").html("")
+<% if @donation.errors.any? %>
+  <% @donation.errors.full_messages.each do |message| %>
+    $("div.errors").append($("<div />").html("<%= message.html_safe %>").addClass("alert alert-danger"))
+  <% end %>
+<% else %>
+  $("#donationModal").modal("hide")
+<% end %>

--- a/app/views/donations/update.js.erb
+++ b/app/views/donations/update.js.erb
@@ -1,0 +1,10 @@
+$("div.errors").html("")
+<% if @donation.errors.any? %>
+  <% @donation.errors.full_messages.each do |message| %>
+    $("div.errors").append($("<div />").html("<%= message.html_safe %>").addClass("alert alert-danger"))
+  <% end %>
+<% else %>
+  $("#editDonation").modal("hide")
+  $('body').removeClass('modal-open');
+  $('.modal-backdrop').remove();
+<% end %>

--- a/app/views/donors/show.html.slim
+++ b/app/views/donors/show.html.slim
@@ -1,3 +1,7 @@
+- if notice.present?
+  .alert.alert-success role="alert"
+    = notice
+
 #edit_partial
   = link_to edit_donor_url, remote: true do
     i class="fa fa-pencil fa-lg"
@@ -9,7 +13,6 @@ div
   h2 Total Amount Donated
   h1 $#{number_with_delimiter(@donor.total_donations(params[:cause_id]), delimiter: ",")}
   h5 Donor since #{@donor.created_at.strftime("%d %b %Y")} (#{time_ago_in_words(@donor.created_at)})
-
 .table-responsive
   table.table
     thead.thead-default
@@ -20,16 +23,16 @@ div
         th Event
         th
     tbody
-      - @donor.donations.each do |donation|
-        tr
-          td = l donation.created_at.to_date, format: donation.created_at.year == Date.today.year ? :short : :default
-          td $#{donation.amount.to_i}
-          td = donation.cause&.name
-          td
-          - if donation.event.present?
-            = link_to donation.event.name, event_path(donation.event)
-          td
-            = link_to edit_donation_path(donation), remote: true do
-              i.fa.fa-pencil.fa-lg
+
+      - if @donor.donations.present?
+        - @donor.donations.each do |donation|
+         tr
+            td = l donation.created_at.to_date, format: donation.created_at.year == Date.today.year ? :short : :default
+            td $#{donation.amount.to_i}
+            td = donation.cause&.name
+            td = link_to donation.event&.name, event_path(donation.event)
+            td
+              = link_to edit_donation_path(donation), remote: true do
+                i.fa.fa-pencil.fa-lg
 
 .modal.fade#editDonation role="dialog" aria-labelledby="myModalLabel" aria-hidden="true"

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -10,9 +10,5 @@ html
       = render "donations/new"
       = render "layouts/navbar"
 
-    - flash.each do |key, value|
-      .alert
-        = value
-
     .container
       = yield


### PR DESCRIPTION
This change fixes issue #66: There are no alerts displayed in the donations modal when creating or editing a Donation.

Screenshot of creating a donation:
![image](https://cloud.githubusercontent.com/assets/16523290/19898002/368f28ee-a095-11e6-9b7f-9ccbba58344a.png)

Screenshot of editing a donation:
![image](https://cloud.githubusercontent.com/assets/16523290/19898011/40587efc-a095-11e6-8c98-e24ee883bb98.png)
 
---

**Before submitting, check that:**

 - [ ] You have added (passing) tests for your code.
 - [ ] You have written good* commit messages.
 - [ ] You have squashed relevant commits together.
 - [ ] You have ensured that RuboCop is passing.
 - [ ] Your PR relates to one subject, with a clear title and
       description using complete, grammatically correct sentences.

---

If your change contains views, ensure that:

 - [ ] You have included a screenshot of the new view.
