### PR TITLE
Improve modals' UX

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -29,3 +29,9 @@ $(document).on('turbolinks:load', function() {
     todayHighlight: true
   });
 });
+
+$( document ).ready(function() {
+  $('.modal').on('show.bs.modal', function (e) {
+    $("div.errors").html("");
+  });
+});

--- a/app/views/donations/_form.html.slim
+++ b/app/views/donations/_form.html.slim
@@ -4,11 +4,11 @@
 
 .form-group
   label.form-control-label for="causeOrEvent" Cause:
-  = f.select :cause_id, Cause.pluck(:name, :id), {}, class:"form-control"
+  = f.select :cause_id, Cause.pluck(:name, :id), { selected: f.object.cause_id }, class:"form-control"
 
 .form-group
   label.form-control-label for="causeOrEvent" Event:
-  = f.select :event_id, Event.pluck(:name, :id), {}, class:"form-control"
+  = f.select :event_id, Event.pluck(:name, :id), { include_blank: true }, class:"form-control"
 
 .actions
   = f.submit "Save changes", class: "btn btn-primary form-control"

--- a/app/views/donors/show.html.slim
+++ b/app/views/donors/show.html.slim
@@ -25,7 +25,9 @@ div
           td = l donation.created_at.to_date, format: donation.created_at.year == Date.today.year ? :short : :default
           td $#{donation.amount.to_i}
           td = donation.cause&.name
-          td = link_to donation.event&.name, event_path(donation.event)
+          td
+          - if donation.event.present?
+            = link_to donation.event.name, event_path(donation.event)
           td
             = link_to edit_donation_path(donation), remote: true do
               i.fa.fa-pencil.fa-lg

--- a/db/seeds/causes.rb
+++ b/db/seeds/causes.rb
@@ -1,12 +1,20 @@
 puts "Seeding Causes ..."
 
 causes = [
+  shortcode: "GE",
+  name: "General"
+],
+[
   shortcode: "HH",
   name: "Halfway House"
 ],
 [
-  shortcode: "GE",
-  name: "General"
+  shortcode: "NLC",
+  name: "NLC"
+],
+[
+  shortcode: "RTC",
+  name: "RTC"
 ]
 
 unless Cause.any?


### PR DESCRIPTION
This change makes several improvements:

- [Fix #71] Makes "General" cause a default option when creating a `donation` ;
- [Fix #72] Lets a User create a `donation` with no `event` associated;
- [Fix #73] Hides error messages from modals after a modal is closed.

**Note:** This change updated the `seed.rb` file. Please run `rake db:drop db:create db:migrate db:seed`.

---

See the screenshot below:

![screencapture-localhost-3000-donors-1478051330484](https://cloud.githubusercontent.com/assets/19661205/19913917/ab2759dc-a0e1-11e6-8bc4-46dd35022d72.png)


---

**Before submitting, check that:**

 - [ ] You have added (passing) tests for your code.
 - [x] You have written good* commit messages.
 - [x] You have squashed relevant commits together.
 - [x] You have ensured that RuboCop is passing.
 - [x] Your PR relates to one subject, with a clear title and
       description using complete, grammatically correct sentences.

---

If your change contains views, ensure that:

 - [x] You have included a screenshot of the new view.

---

*If you do not know what makes a good commit message, or why it
is important, please refer to these resources: [1][1], [2][2], [3][3].

[1]: https://robots.thoughtbot.com/5-useful-tips-for-a-better-commit-message
[2]: http://chris.beams.io/posts/git-commit/
[3]: https://github.com/blog/1943-how-to-write-the-perfect-pull-request

