### PR TITLE
Add a diagram showing donations per cause to Dashboard page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,9 @@ gem "jquery-rails"
 
 gem "turbolinks"
 
+gem "chartkick"
+gem "groupdate"
+
 group :production do
   gem "rails_12factor"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,6 +50,7 @@ GEM
       railties (>= 3.0)
     builder (3.2.2)
     byebug (9.0.6)
+    chartkick (2.1.1)
     clearance (1.15.1)
       bcrypt
       email_validator (~> 1.4)
@@ -80,6 +81,8 @@ GEM
       railties (>= 3.2, < 5.1)
     globalid (0.3.7)
       activesupport (>= 4.1.0)
+    groupdate (3.1.1)
+      activesupport (>= 3)
     i18n (0.7.0)
     jquery-rails (4.2.1)
       rails-dom-testing (>= 1, < 3)
@@ -215,11 +218,13 @@ DEPENDENCIES
   bootstrap (~> 4.0.0.alpha4)
   bootstrap-datepicker-rails
   byebug
+  chartkick
   clearance
   codeclimate-test-reporter
   coffee-rails (~> 4.1.0)
   factory_girl_rails
   font-awesome-rails
+  groupdate
   jquery-rails
   pg (~> 0.15)
   rails (~> 4.2.7.1)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -18,6 +18,8 @@
 //= require bootstrap-datepicker/core
 //= require bootstrap-datepicker/locales/bootstrap-datepicker.en-GB.js
 //= require bootstrap-sprockets
+//= require Chart.bundle
+//= require chartkick
 //= require_tree .
 
 

--- a/app/models/donation.rb
+++ b/app/models/donation.rb
@@ -1,6 +1,4 @@
 class Donation < ActiveRecord::Base
-  default_scope { order(created_at: :desc) }
-
   belongs_to :donor, inverse_of: :donations
   belongs_to :cause, inverse_of: :donations
   belongs_to :event, inverse_of: :donations

--- a/app/views/donations/index.html.slim
+++ b/app/views/donations/index.html.slim
@@ -3,5 +3,8 @@
     .card-block
       h1 Total Donations for #{Date.today.year}
       h1 $#{@donations.donations_per_year(Date.current.year).sum(:amount).round}
+= area_chart @donations.includes(:cause).where("donations.created_at BETWEEN ? AND ?", Date.current.beginning_of_year, Date.current.end_of_year).group("causes.name").group_by_week("donations.created_at").sum(:amount)
+
+
 
 

--- a/db/seeds/causes.rb
+++ b/db/seeds/causes.rb
@@ -17,6 +17,7 @@ causes = [
   name: "RTC"
 ]
 
+
 unless Cause.any?
   Cause.create!(causes)
 end

--- a/db/seeds/donations.rb
+++ b/db/seeds/donations.rb
@@ -4,25 +4,59 @@ donations = [
   donor: Donor.first,
   cause: Cause.first,
   amount: 100,
-  event: Event.first
+  event: Event.first,
+  created_at: 6.months.ago
 ],
 [
   donor: Donor.second,
   cause: Cause.first,
   amount: 200,
-  event: Event.first
+  event: Event.first,
+  created_at: 2.months.ago
 ],
 [
   donor: Donor.second,
   cause: Cause.first,
+  amount: 350,
+  event: Event.first,
+  created_at: 2.months.ago - 5.days
+],
+[
+  donor: Donor.second,
+  cause: Cause.second,
   amount: 300,
-  event: Event.second
+  event: Event.second,
+  created_at: 4.months.ago
 ],
 [
   donor: Donor.second,
-  cause: Cause.first,
+  cause: Cause.second,
   amount: 400,
-  event: Event.third
+  event: Event.third,
+  created_at: 5.days.ago
+],
+[
+  donor: Donor.third,
+  cause: Cause.second,
+  amount: 450,
+  event: Event.third,
+  created_at: 2.days.ago
+],
+[
+  donor: Donor.third,
+  cause: Cause.second,
+  amount: 550,
+  created_at: 2.days.ago
+],
+[
+  donor: Donor.third,
+  cause: Cause.third,
+  amount: 500
+],
+[
+  donor: Donor.third,
+  cause: Cause.fourth,
+  amount: 600
 ]
 
 unless Donation.any?

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -60,4 +60,18 @@ RSpec.describe EventsController, type: :controller do
       it { expect(response).to have_http_status(:success) }
     end
   end
+
+  describe "PUT #update/:id" do
+    let(:event) { Event.create(name: "Test Event", start_on: 2.years.ago, end_on: 1.year.ago + 3.days) }
+    let(:attr) { { name: "Edited event", start_on: 1.year.ago.to_date, end_on: (1.year.ago + 1.day).to_date } }
+
+    before(:each) do
+      put :update, id: event.id, event: attr
+      event.reload
+    end
+
+    it { expect(event.name).to eq attr[:name] }
+    it { expect(event.start_on).to eq attr[:start_on] }
+    it { expect(event.end_on).to eq attr[:end_on] }
+  end
 end


### PR DESCRIPTION
This change adds a Digram showing Donations per cause for current year on "Dashboard" page.

**Note:** This change updated seed files and Gemfile. Please run `rake db:drop db:create db:migrate db:seed` and `bundle install`.

---

See the screenshot below:

![screencapture-localhost-3000-donations-1478325197768](https://cloud.githubusercontent.com/assets/19661205/20027965/3d6a4456-a35f-11e6-8eb5-7cb25ff7de5c.png)


**Before submitting, check that:**

 - [ ] You have added (passing) tests for your code.
 - [x] You have written good* commit messages.
 - [x] You have squashed relevant commits together.
 - [x] You have ensured that RuboCop is passing.
 - [x] Your PR relates to one subject, with a clear title and
       description using complete, grammatically correct sentences.

---

If your change contains views, ensure that:

 - [x] You have included a screenshot of the new view.

---

*If you do not know what makes a good commit message, or why it
is important, please refer to these resources: [1][1], [2][2], [3][3].

[1]: https://robots.thoughtbot.com/5-useful-tips-for-a-better-commit-message
[2]: http://chris.beams.io/posts/git-commit/
[3]: https://github.com/blog/1943-how-to-write-the-perfect-pull-request