### PR TITLE
[Fix #79] Edit column filters

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,21 @@
 module ApplicationHelper
+  def sortable(column)
+    css_class =
+      if column.to_s == params[:sort]
+        if params[:direction] == "ASC"
+          "fa fa-caret-up fa-lg text-success"
+        else
+          "fa fa-caret-down fa-lg text-success"
+        end
+      else
+        "fa fa-sort fa-lg"
+      end
+    direction =
+      if column.to_s == params[:sort] && params[:direction] == "ASC"
+        "DESC"
+      else
+        "ASC"
+      end
+    link_to "", safe_params(sort: column.to_s, direction: direction), class: css_class
+  end
 end

--- a/app/views/donors/index.html.slim
+++ b/app/views/donors/index.html.slim
@@ -18,16 +18,16 @@
                 .col-xs-6.col-sm-6.col-md-4
                   = select_tag :cause_id, options_from_collection_for_select(Cause.all, :id, :name, params[:cause_id]), prompt: "Filter by cause:", class: 'form-control', onchange: "cause_toggle(this.value)"
         tr
-          th Name
-          th NRIC/UEN
+          th 
+            | Name
+            = sortable :name
+          th 
+            | NRIC/UEN
+            = sortable :identification
           th
             | Total Donations
-            .btn-group.btn-group-sm
-              button.btn.btn-secondary data-toggle="dropdown" type="button"
-                i.fa.fa-caret-down.fa-lg
-              ul.dropdown-menu role="menu"
-                li= link_to "Lowest first", safe_params(sort: "total_donations", direction: "ASC")
-                li= link_to "Highest first", safe_params(sort: "total_donations", direction: "DESC")
+            = sortable :total_donations
+          th
       tbody
         tr
           - if @donors.blank? && params[:search].present?

--- a/app/views/events/_index.html.slim
+++ b/app/views/events/_index.html.slim
@@ -16,24 +16,16 @@
                     span.input-group-btn
                       = submit_tag "Search", name: :nil, class: "btn btn-secondary"
         tr.thead-default
-          th Name
+          th 
+            | Name
+            = sortable :name
           th 
             | Date
-            .btn-group.btn-group-sm
-              button.btn.btn-secondary data-toggle="dropdown" type="button"
-                i.fa.fa-caret-down.fa-lg
-              ul.dropdown-menu role="menu"
-                li= link_to "Latest event first", safe_params(sort: "start_on", direction: "DESC")
-                li= link_to "Earliest event first", safe_params(sort: "start_on", direction: "ASC")
+            = sortable :start_on
           th 
             | Total Donations
-            .btn-group.btn-group-sm
-              button.btn.btn-secondary data-toggle="dropdown" type="button"
-                i.fa.fa-caret-down.fa-lg
-              ul.dropdown-menu role="menu"
-                li= link_to "Lowest first", safe_params(sort: "total_donations", direction: "ASC")
-                li= link_to "Highest first", safe_params(sort: "total_donations", direction: "DESC")
-
+            = sortable :total_donations
+          th
       tbody.events-index
         tr
           - if @events.blank?


### PR DESCRIPTION
This change edits the column filters in the donor#index and event#index views so that it is easier to see what filters are on/off. It also adds filters to the name and NRIC/UEN columns of the donor#index view.

However, there is a rubocop offense that the method "sortable" has too many lines.

Screen shot of donor#index view:
![image](https://cloud.githubusercontent.com/assets/16523290/20030131/dc1274fe-a399-11e6-9f46-0433194bbc8c.png)

Screen shot of event#index view:
![image](https://cloud.githubusercontent.com/assets/16523290/20030134/ec7f105e-a399-11e6-99b8-116906f0002a.png)


---

**Before submitting, check that:**

 - [ ] You have added (passing) tests for your code.
 - [x] You have written good* commit messages.
 - [ ] You have squashed relevant commits together.
 - [ ] You have ensured that RuboCop is passing.
 - [x] Your PR relates to one subject, with a clear title and
       description using complete, grammatically correct sentences.

---

If your change contains views, ensure that:

 - [x] You have included a screenshot of the new view.

---

*If you do not know what makes a good commit message, or why it
is important, please refer to these resources: [1][1], [2][2], [3][3].

[1]: https://robots.thoughtbot.com/5-useful-tips-for-a-better-commit-message
[2]: http://chris.beams.io/posts/git-commit/
[3]: https://github.com/blog/1943-how-to-write-the-perfect-pull-request

