### PR TITLE
Allow Users to see Top Donors per Cause on Dashboard page

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -18,5 +18,9 @@
  @import "font-awesome";
 
  table .input-group {
-  border-collapse: collapse;
+   border-collapse: collapse;
+ }
+
+ .margin-top {
+   margin-top: 3rem;
  }

--- a/app/controllers/donations_controller.rb
+++ b/app/controllers/donations_controller.rb
@@ -17,6 +17,7 @@ class DonationsController < ApplicationController
 
   def index
     @donations = Donation.all
+    @causes = Cause.all
   end
 
   # PATCH /update

--- a/app/models/cause.rb
+++ b/app/models/cause.rb
@@ -4,4 +4,8 @@ class Cause < ActiveRecord::Base
 
   validates :shortcode, presence: true
   validates :name, presence: true, uniqueness: true
+
+  def top_donation_for_year(year = Date.current.year)
+    donations.where("donations.created_at BETWEEN ? AND ?", Date.current.beginning_of_year, Date.current.end_of_year).order("amount DESC").first
+  end
 end

--- a/app/views/donations/index.html.slim
+++ b/app/views/donations/index.html.slim
@@ -1,9 +1,21 @@
 .card.card-inverse.card-info.text-xs-center
-  .card.card-inverse.card-info.text-xs-center
-    .card-block
-      h1 Total Donations for #{Date.today.year}
-      h1 $#{@donations.donations_per_year(Date.current.year).sum(:amount).round}
+  .card-block
+    h1 Total Donations for #{Date.current.year}
+    h1 $#{@donations.donations_per_year(Date.current.year).sum(:amount).round}
 = area_chart @donations.includes(:cause).where("donations.created_at BETWEEN ? AND ?", Date.current.beginning_of_year, Date.current.end_of_year).group("causes.name").group_by_week("donations.created_at").sum(:amount)
+
+.row.margin-top
+  - @causes.each do |cause|
+    .col-xs-6.col-md-3
+      .card.card-outline-primary.text-xs-center
+        .card-header = cause.name
+        .card-block
+          h4.card-title Top Donor:
+          p #{cause.top_donation_for_year.donor.name}
+          p $#{cause.top_donation_for_year.amount.round}
+
+
+
 
 
 

--- a/app/views/donors/show.html.slim
+++ b/app/views/donors/show.html.slim
@@ -30,7 +30,9 @@ div
             td = l donation.created_at.to_date, format: donation.created_at.year == Date.today.year ? :short : :default
             td $#{donation.amount.to_i}
             td = donation.cause&.name
-            td = link_to donation.event&.name, event_path(donation.event)
+            td
+              -if donation.event.present?
+                = link_to donation.event.name, event_path(donation.event)
             td
               = link_to edit_donation_path(donation), remote: true do
                 i.fa.fa-pencil.fa-lg

--- a/spec/models/cause_spec.rb
+++ b/spec/models/cause_spec.rb
@@ -5,4 +5,15 @@ RSpec.describe Cause, type: :model do
 
   it { is_expected.to validate_presence_of(:shortcode) }
   it { is_expected.to validate_presence_of(:name) }
+
+  describe ".top_donation_for_year" do
+    before do
+      @cause = create(:cause)
+      @donation100 = create(:donation, cause: @cause, amount: 100)
+      @donation200 = create(:donation, cause: @cause, amount: 200)
+      @donation300 = create(:donation, cause: @cause, amount: 300)
+    end
+
+    it { expect(@cause.top_donation_for_year).to eq(@donation300) }
+  end
 end


### PR DESCRIPTION
This change adds Topd Donors per `cause` to `donations#index` page.

---

See the screenshot below:

![screencapture-localhost-3000-donations-1478489113069](https://cloud.githubusercontent.com/assets/19661205/20045593/7c0f89ee-a4dd-11e6-93b4-b432259fb438.png)

**Before submitting, check that:**

 - [x] You have added (passing) tests for your code.
 - [x] You have written good* commit messages.
 - [x] You have squashed relevant commits together.
 - [x] You have ensured that RuboCop is passing.
 - [x] Your PR relates to one subject, with a clear title and
       description using complete, grammatically correct sentences.

---

If your change contains views, ensure that:

 - [x] You have included a screenshot of the new view.

---

*If you do not know what makes a good commit message, or why it
is important, please refer to these resources: [1][1], [2][2], [3][3].

[1]: https://robots.thoughtbot.com/5-useful-tips-for-a-better-commit-message
[2]: http://chris.beams.io/posts/git-commit/
[3]: https://github.com/blog/1943-how-to-write-the-perfect-pull-request


Fix event link on "donors#show" page
Add CSS styling