### PR TITLE
[Fix#86] Add CSS styling to sorting icons

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -24,3 +24,18 @@
  .margin-top {
    margin-top: 3rem;
  }
+
+ th a.sort-icon {
+   margin-left: 5px;
+     &:focus,
+     &:hover,
+     &:active {
+       text-decoration: none;
+     }
+     &.sort-icon-down {
+       vertical-align: -25%;
+     }
+     &.sort-icon-up {
+       vertical-align: 0px;
+     }
+  }

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -3,12 +3,12 @@ module ApplicationHelper
     css_class =
       if column.to_s == params[:sort]
         if params[:direction] == "ASC"
-          "fa fa-caret-up fa-lg text-success"
+          "fa fa-caret-up fa-lg text-success sort-icon sort-icon-up"
         else
-          "fa fa-caret-down fa-lg text-success"
+          "fa fa-caret-down fa-lg text-success sort-icon sort-icon-down"
         end
       else
-        "fa fa-sort fa-lg"
+        "fa fa-sort fa-lg sort-icon sort-icon-both"
       end
     direction =
       if column.to_s == params[:sort] && params[:direction] == "ASC"


### PR DESCRIPTION
This change adds some CSS to style the sorting icons in tables. 

See the screenshots below:

---

![screen shot 2016-11-11 at 10 33 48 am](https://cloud.githubusercontent.com/assets/19661205/20202514/9c755c5c-a7fa-11e6-8e94-9b3dad3d125f.png)
![screen shot 2016-11-11 at 10 34 00 am](https://cloud.githubusercontent.com/assets/19661205/20202523/b3c12d82-a7fa-11e6-9f12-69f5c10797e9.png)


**Before submitting, check that:**

 - [ ] You have added (passing) tests for your code.
 - [x] You have written good* commit messages.
 - [x] You have squashed relevant commits together.
 - [x] You have ensured that RuboCop is passing.
 - [x] Your PR relates to one subject, with a clear title and
       description using complete, grammatically correct sentences.

---

If your change contains views, ensure that:

 - [x] You have included a screenshot of the new view.

---

*If you do not know what makes a good commit message, or why it
is important, please refer to these resources: [1][1], [2][2], [3][3].

[1]: https://robots.thoughtbot.com/5-useful-tips-for-a-better-commit-message
[2]: http://chris.beams.io/posts/git-commit/
[3]: https://github.com/blog/1943-how-to-write-the-perfect-pull-request


