### PR TITLE
[Fix #93] Use username and password instead of an API key for SendGrid

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -80,8 +80,8 @@ Rails.application.configure do
   config.action_mailer.default_url_options = { host: "localhost:3000" }
 
   ActionMailer::Base.smtp_settings = {
-    user_name: "apikey",
-    password: "SGAPIKEY",
+    user_name: ENV["SENDGRID_USERNAME"],
+    password: ENV["SENDGRID_PASSWORD"],
     domain: "http://highpoint.herokuapp.com",
     address: "smtp.sendgrid.net",
     port: 587,


### PR DESCRIPTION
This change edits `production.rb` to work with `SendGrid` on Heroku.

@Drenmi could you please check that those variables were created?

```
heroku config:get SENDGRID_USERNAME
appXYZ@heroku.com

$ heroku config:get SENDGRID_PASSWORD
password

```

If they were, this change might fix the error we currently have. 

---

**Before submitting, check that:**

 - [ ] You have added (passing) tests for your code.
 - [x] You have written good* commit messages.
 - [x] You have squashed relevant commits together.
 - [x] You have ensured that RuboCop is passing.
 - [x] Your PR relates to one subject, with a clear title and
       description using complete, grammatically correct sentences.

---

*If you do not know what makes a good commit message, or why it
is important, please refer to these resources: [1][1], [2][2], [3][3].

[1]: https://robots.thoughtbot.com/5-useful-tips-for-a-better-commit-message
[2]: http://chris.beams.io/posts/git-commit/
[3]: https://github.com/blog/1943-how-to-write-the-perfect-pull-request


