### PR TITLE
Allow user to filter donors in events/show page

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -25,11 +25,7 @@ class EventsController < ApplicationController
 
   def show
     @event = find_event(params[:id])
-    @donations = if params[:search]
-                   @event.donations.search(params[:search])
-                 else
-                   @event.donations
-                 end
+    @donations = DonationsFinder.new(params, @event).find_all
   end
 
   # PATCH /update

--- a/app/finders/donations_finder.rb
+++ b/app/finders/donations_finder.rb
@@ -1,0 +1,36 @@
+class DonationsFinder
+  def initialize(params, event)
+    @sort_column = params[:sort] || "created_at"
+    @sort_direction = params[:direction] || "DESC"
+    @keyword = params[:search]
+    @event = event
+    @result = @event.donations
+  end
+
+  def find_all
+    if @event.donations.present?
+      search
+      sort
+    else
+      @result
+    end
+  end
+
+  private
+
+  def search
+    @result = @result.search(@keyword) if @keyword
+  end
+
+  def sort
+    if @sort_column == "donor_name"
+      if @sort_direction == "ASC"
+        @result.joins(:donor).order("donors.name")
+      else
+        @result.joins(:donor).order("donors.name").reverse
+      end
+    else
+      @result.order(@sort_column + " " + @sort_direction)
+    end
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -10,6 +10,7 @@ module ApplicationHelper
       else
         "fa fa-sort fa-lg sort-icon sort-icon-both"
       end
+
     direction =
       if column.to_s == params[:sort] && params[:direction] == "ASC"
         "DESC"

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -14,7 +14,7 @@ class Event < ActiveRecord::Base
 
   scope :search, ->(keyword) { where("name ILIKE ?", "%#{keyword}%") }
 
-  def total_donations
-    donations.sum(:amount).round
+  def total_donations(keyword = nil)
+    donations.search(keyword).sum(:amount).round
   end
 end

--- a/app/views/events/show.html.slim
+++ b/app/views/events/show.html.slim
@@ -5,7 +5,7 @@
 .card.card-inverse.card-info.text-xs-center
   .card-block
     h1 Total amount donated
-    h1 $#{number_with_delimiter(@event.total_donations, delimiter: ",")}
+    h1 $#{number_with_delimiter(@event.total_donations(params[:search]), delimiter: ",")}
 .table-responsive
   = form_tag @event, method: :get do
     table.table
@@ -20,9 +20,15 @@
                     span.input-group-btn
                       = submit_tag "Search", name: :nil, class: "btn btn-secondary"
         tr
-          th Name
-          th Date
-          th Total Donations
+          th 
+            | Name
+            = sortable :donor_name
+          th 
+            | Date
+            = sortable :created_at
+          th 
+            | Donation
+            = sortable :amount
       tbody
         tr
           - if @donations.blank? && params[:search].present?

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -51,8 +51,8 @@ RSpec.describe EventsController, type: :controller do
   end
 
   describe "GET #show" do
-    let(:donation) { instance_double(Donation, amount: 100) }
-    let(:event) { instance_double(Event, donations: donation) }
+    let(:donation) { FactoryGirl.build(:donation, amount: 100) }
+    let(:event) { FactoryGirl.build(:event, donations: [donation]) }
 
     before { get :show, id: 1 }
 


### PR DESCRIPTION
This change allows a user to filter donors and their donations in the events/show page.

Screen shot:

![image](https://cloud.githubusercontent.com/assets/16523290/20453601/bc6c027e-ae65-11e6-84a9-a035f58cf13f.png)

---

**Before submitting, check that:**

 - [ ] You have added (passing) tests for your code.
 - [ ] You have written good* commit messages.
 - [ ] You have squashed relevant commits together.
 - [ ] You have ensured that RuboCop is passing.
 - [ ] Your PR relates to one subject, with a clear title and
       description using complete, grammatically correct sentences.

---

If your change contains views, ensure that:

 - [ ] You have included a screenshot of the new view.

---

*If you do not know what makes a good commit message, or why it
is important, please refer to these resources: [1][1], [2][2], [3][3].

[1]: https://robots.thoughtbot.com/5-useful-tips-for-a-better-commit-message
[2]: http://chris.beams.io/posts/git-commit/
[3]: https://github.com/blog/1943-how-to-write-the-perfect-pull-request

