### PR TITLE
Add pagination to donors index page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,8 @@ gem "groupdate"
 
 gem "sendgrid-ruby"
 
+gem "will_paginate"
+
 group :production do
   gem "rails_12factor"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -213,6 +213,7 @@ GEM
       binding_of_caller (>= 0.7.2)
       railties (>= 4.0)
       sprockets-rails (>= 2.0, < 4.0)
+    will_paginate (3.1.5)
 
 PLATFORMS
   ruby
@@ -243,9 +244,10 @@ DEPENDENCIES
   turbolinks
   uglifier (>= 1.3.0)
   web-console (~> 2.0)
+  will_paginate
 
 RUBY VERSION
    ruby 2.3.1p112
 
 BUNDLED WITH
-   1.13.3
+   1.13.6

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -39,3 +39,7 @@
        vertical-align: 0px;
      }
   }
+
+.page-links-centered {
+  text-align: center;
+}

--- a/app/controllers/donors_controller.rb
+++ b/app/controllers/donors_controller.rb
@@ -6,7 +6,7 @@ class DonorsController < ApplicationController
 
   # GET /donors
   def index
-    @donors = DonorsFinder.new(params).find_all
+    @donors = DonorsFinder.new(params).find_all.paginate(page: params[:page])
   end
 
   def update

--- a/app/models/donor.rb
+++ b/app/models/donor.rb
@@ -1,4 +1,6 @@
 class Donor < ActiveRecord::Base
+  self.per_page = 15
+
   default_scope { order(created_at: :desc) }
 
   has_many :donations, inverse_of: :donor

--- a/app/views/donors/index.html.slim
+++ b/app/views/donors/index.html.slim
@@ -37,3 +37,7 @@
             td = donor.name
             td = link_to donor.identification, donor_path(donor)
             td $#{number_with_delimiter(donor.total_donations(params[:cause_id]), delimiter: ",")}
+
+.page-links-centered
+  .row
+    = will_paginate @donors


### PR DESCRIPTION
This change adds pagination to the donors index page so that there is a maximum of 15 donors per page.

Screen shot of the page links:
![image](https://cloud.githubusercontent.com/assets/16523290/20453868/317b60b2-ae6d-11e6-80b9-c757d0a545c7.png)


---

**Before submitting, check that:**

 - [ ] You have added (passing) tests for your code.
 - [x] You have written good* commit messages.
 - [ ] You have squashed relevant commits together.
 - [x] You have ensured that RuboCop is passing.
 - [x] Your PR relates to one subject, with a clear title and
       description using complete, grammatically correct sentences.

---

*If you do not know what makes a good commit message, or why it
is important, please refer to these resources: [1][1], [2][2], [3][3].

[1]: https://robots.thoughtbot.com/5-useful-tips-for-a-better-commit-message
[2]: http://chris.beams.io/posts/git-commit/
[3]: https://github.com/blog/1943-how-to-write-the-perfect-pull-request


