### PR TITLE
Disable "month" field in reports form if no year is chosen 

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -36,6 +36,14 @@ $( document ).ready(function() {
   $('.modal').on('show.bs.modal', function (e) {
     $("div.errors").html("");
   });
+
+  $('#report-year').change(function() {
+    if (!$(this).val()) {
+      $("#report-month").attr("disabled", "disabled");
+    } else {
+      $("#report-month").removeAttr("disabled");
+    }
+  });
 });
 
 function check(input) {

--- a/app/views/reports/index.html.slim
+++ b/app/views/reports/index.html.slim
@@ -6,11 +6,11 @@
         = form_tag(url: reports_path, method: :post)
           .form-group.col-xs-6
             label.form-control-label for="year" Year:
-            = select_year(@report.present? ?  @report.year.to_i : Date.today , { start_year: Donation.minimum(:created_at).year, end_year: Date.current.year,  prompt: 'All'}, {class:"form-control"})
+            = select_year(@report.present? ?  @report.year.to_i : Date.today , { start_year: Donation.minimum(:created_at).year, end_year: Date.current.year,  prompt: "All"}, {class:"form-control", id: "report-year"})
 
           .form-group.col-xs-6
             label.form-control-label for="month" Month:
-            = select_month(@report.present? ? @report.month.to_i : Date.today, {prompt: 'All'}, {class:"form-control"} )
+            = select_month(@report.present? ? @report.month.to_i : Date.today, {prompt: "All"}, {class: "form-control", id: "report-month"} )
 
           .form-group.col-xs-6
             label.form-control-label for="cause" Cause:


### PR DESCRIPTION
This change adds JS to disable a "month" field in report form on `reports/index` page if no "year" is chosen.

See the screenshots below:

---

![screencapture-localhost-3000-donations-reports-1479568997007](https://cloud.githubusercontent.com/assets/19661205/20456295/2fe7bf06-aeaf-11e6-86b6-07f8632ea7ed.png)


**Before submitting, check that:**

 - [ ] You have added (passing) tests for your code.
 - [x] You have written good* commit messages.
 - [x] You have squashed relevant commits together.
 - [x] You have ensured that RuboCop is passing.
 - [x] Your PR relates to one subject, with a clear title and
       description using complete, grammatically correct sentences.

---

If your change contains views, ensure that:

 - [x] You have included a screenshot of the new view.

---

*If you do not know what makes a good commit message, or why it
is important, please refer to these resources: [1][1], [2][2], [3][3].

[1]: https://robots.thoughtbot.com/5-useful-tips-for-a-better-commit-message
[2]: http://chris.beams.io/posts/git-commit/
[3]: https://github.com/blog/1943-how-to-write-the-perfect-pull-request


