### PR TITLE
Allow Users generate a report for a particular event

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -32,7 +32,7 @@ $(document).on('turbolinks:load', function() {
   });
 });
 
-$( document ).ready(function() {
+$(document).ready(function() {
   $('.modal').on('show.bs.modal', function (e) {
     $("div.errors").html("");
   });

--- a/app/finders/donations_reports_finder.rb
+++ b/app/finders/donations_reports_finder.rb
@@ -26,10 +26,10 @@ class DonationsReportsFinder
   end
 
   def filter_by_cause(cause_id)
-    @result = @result.where("causes.id = ?", cause_id)
+    @result = @result.joins(:cause).where("causes.id = ?", cause_id)
   end
 
   def filter_by_event(event_id)
-    @result = @result.includes(:event).where("events.id = ?", event_id)
+    @result = @result.joins(:event).includes(:event).where("events.id = ?", event_id)
   end
 end

--- a/app/views/events/show.html.slim
+++ b/app/views/events/show.html.slim
@@ -1,44 +1,48 @@
 = link_to "< Back to Event List", events_path
-.row
-  .col-xs-12
+.row.margin-top
+  .col-xs-8
     h1 = @event.name
     p = event_dates(@event)
     p.metadata = whodunnit(@event)
+  col-xs-2
+    = link_to "Generate Report", reports_path(event_id: @event.id), class: "btn btn-primary pull-right"
 
-.card.card-inverse.card-info.text-xs-center
-  .card-block
-    h1 Total amount donated
-    h1 $#{number_with_delimiter(@event.total_donations(params[:search]), delimiter: ",")}
-.table-responsive
-  = form_tag @event, method: :get do
-    table.table
-      thead.thead-default
-        tr
-          td colspan="4"
-            .container-fluid
-              .row
-                .col-xs-12.col-md-6.offset-md-6
-                  div.input-group
-                    = text_field_tag :search, params[:search], placeholder: "Search by donor name ...", class: "form-control"
-                    span.input-group-btn
-                      = submit_tag "Search", name: :nil, class: "btn btn-secondary"
-        tr
-          th Name #{sortable :donor_name}
-          th Date #{sortable :created_at}
-          th Donation #{sortable :amount}
-          th
-      tbody
-        tr
-          - if @donations.blank? && params[:search].present?
-            h4 There is no donor matching <em>#{params[:search]}</em>.
-        - @donations.each do |donation|
+.row
+  .card.card-inverse.card-info.text-xs-center
+    .card-block
+      h1 Total amount donated
+      h1 $#{number_with_delimiter(@event.total_donations(params[:search]), delimiter: ",")}
+.row
+  .table-responsive
+    = form_tag @event, method: :get do
+      table.table
+        thead.thead-default
           tr
-            td = donation.donor.name
-            td = l donation.created_at.to_date
-            td $#{number_with_delimiter(donation.amount.round, delimiter: ",")}
-            td
-              = link_to edit_donation_path(donation), remote: true do
-                i.fa.fa-pencil.fa-lg
+            td colspan="4"
+              .container-fluid
+                .row
+                  .col-xs-12.col-md-6.offset-md-6
+                    div.input-group
+                      = text_field_tag :search, params[:search], placeholder: "Search by donor name ...", class: "form-control"
+                      span.input-group-btn
+                        = submit_tag "Search", name: :nil, class: "btn btn-secondary"
+          tr
+            th Name #{sortable :donor_name}
+            th Date #{sortable :created_at}
+            th Donation #{sortable :amount}
+            th
+        tbody
+          tr
+            - if @donations.blank? && params[:search].present?
+              h4 There is no donor matching <em>#{params[:search]}</em>.
+          - @donations.each do |donation|
+            tr
+              td = donation.donor.name
+              td = l donation.created_at.to_date
+              td $#{number_with_delimiter(donation.amount.round, delimiter: ",")}
+              td
+                = link_to edit_donation_path(donation), remote: true do
+                  i.fa.fa-pencil.fa-lg
 
 .modal.fade#editDonation role="dialog" aria-labelledby="myModalLabel" aria-hidden="true"
 

--- a/app/views/reports/_report_table.html.slim
+++ b/app/views/reports/_report_table.html.slim
@@ -9,12 +9,10 @@
         th Amount
     tbody
       tr
-        - if report.donations.blank? && params[:search].present?
-          h4 There is no donor matching <em>#{params[:search]}</em>.
       - report.donations.each do |donation|
         tr
-          td = donation.donor.name
+          td = donation.donor&.name
           td = link_to donation.donor.identification, donor_path(donation.donor)
           td = l donation.created_at.to_date
-          td = donation.cause.name
+          td = donation.cause&.name
           td $#{number_with_delimiter(donation.amount.round, delimiter: ",")}

--- a/app/views/reports/index.html.slim
+++ b/app/views/reports/index.html.slim
@@ -6,11 +6,11 @@
         = form_tag(url: reports_path, method: :post)
           .form-group.col-xs-6
             label.form-control-label for="year" Year:
-            = select_year(@report.present? ?  @report.year.to_i : Date.today , { start_year: Donation.minimum(:created_at).year, end_year: Date.current.year,  prompt: "All"}, {class:"form-control", id: "report-year"})
+            = select_year(@report.present? ?  @report.year.to_i : 0 , { prompt: 'All', start_year: Donation.order("created_at ASC").first.created_at.year, end_year: Date.current.year}, {class:"form-control", id: "report-year"})
 
           .form-group.col-xs-6
             label.form-control-label for="month" Month:
-            = select_month(@report.present? ? @report.month.to_i : Date.today, {prompt: "All"}, {class: "form-control", id: "report-month"} )
+            = select_month(@report.present? ? @report.month.to_i : 0, {prompt: "All"}, {class: "form-control", id: "report-month"} )
 
           .form-group.col-xs-6
             label.form-control-label for="cause" Cause:
@@ -21,7 +21,7 @@
             = select_tag "event_id", options_from_collection_for_select(Event.all, "id", "name", params[:event_id]), prompt: 'All', class:"form-control"
 
           .actions
-            = submit_tag "Get Report", class: "btn btn-primary form-control"
+            = submit_tag "Get Report", class: "btn btn-primary form-control", id: "generateReportButton"
 
 - if @report.present?
   = render "report_chart", report: @report


### PR DESCRIPTION
This change adds a "Generate Report" button to `events/show` page, after pressing which a User gets redirected to `donations/reports` page with the events name prepopulated in the form.

_P.s. the changes in `ReportsHelper` are made only for test purposes, as this file will be removed from the project in another PR._

See the screenshots below:

---

![screencapture-localhost-3000-events-2-1479630912805](https://cloud.githubusercontent.com/assets/19661205/20461690/7937115c-af40-11e6-911d-a6686910eb9c.png)
![screencapture-localhost-3000-donations-reports-1479630924040](https://cloud.githubusercontent.com/assets/19661205/20461691/7f16b6cc-af40-11e6-83f3-8f1214d34b9e.png)


**Before submitting, check that:**

 - [ ] You have added (passing) tests for your code.
 - [x] You have written good* commit messages.
 - [ ] You have squashed relevant commits together.
 - [x] You have ensured that RuboCop is passing.
 - [x] Your PR relates to one subject, with a clear title and
       description using complete, grammatically correct sentences.

---

If your change contains views, ensure that:

 - [x] You have included a screenshot of the new view.

---

*If you do not know what makes a good commit message, or why it
is important, please refer to these resources: [1][1], [2][2], [3][3].

[1]: https://robots.thoughtbot.com/5-useful-tips-for-a-better-commit-message
[2]: http://chris.beams.io/posts/git-commit/
[3]: https://github.com/blog/1943-how-to-write-the-perfect-pull-request

