### PR TITLE
Prompt user to enter donor details when donation is created 

### DIFF
--- a/app/controllers/donations_controller.rb
+++ b/app/controllers/donations_controller.rb
@@ -3,12 +3,14 @@ class DonationsController < ApplicationController
   def create
     donor = find_or_build_donor(donation_params.delete(:donor))
     @donation = Donation.new(donation_params.merge(donor: donor))
-
+    @donor_new_record = @donation.donor.new_record?
     respond_to do |format|
       if @donation.save
         format.js {}
         format.html {}
-        redirect_to donor_path(@donation.donor), notice: "Donation was successfully created."
+        redirect_to donor_path(@donation.donor)
+        flash[:success] = "Donation was successfully created."
+        flash[:warning] = "New donor created. Fill in donor details below." if @donor_new_record
       else
         format.js
       end

--- a/app/views/donors/show.html.slim
+++ b/app/views/donors/show.html.slim
@@ -1,6 +1,5 @@
-- if notice.present?
-  .alert.alert-success role="alert"
-    = notice
+- flash.each do |key, value|
+    div class=("alert alert-#{key}") = value
 
 #edit_partial
   = link_to edit_donor_url, remote: true do


### PR DESCRIPTION
This change prompts a user to enter the details of the donor after creating a donation and getting redirected to the "donors/show" page, if the donor was not already in the database.

Screen shot of donors/show view if donor is a new record:

![image](https://cloud.githubusercontent.com/assets/16523290/20463071/5da25c14-af66-11e6-81ab-afd5b5b1707a.png)


---

**Before submitting, check that:**

 - [ ] You have added (passing) tests for your code.
 - [x] You have written good* commit messages.
 - [ ] You have squashed relevant commits together.
 - [x] You have ensured that RuboCop is passing.
 - [x] Your PR relates to one subject, with a clear title and
       description using complete, grammatically correct sentences.

---

If your change contains views, ensure that:

 - [x] You have included a screenshot of the new view.

---

*If you do not know what makes a good commit message, or why it
is important, please refer to these resources: [1][1], [2][2], [3][3].

[1]: https://robots.thoughtbot.com/5-useful-tips-for-a-better-commit-message
[2]: http://chris.beams.io/posts/git-commit/
[3]: https://github.com/blog/1943-how-to-write-the-perfect-pull-request


