### PR TITLE
[Fix #113] Fix bug that pagination causes redirect to fail when new event is saved

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -7,8 +7,9 @@ class EventsController < ApplicationController
 
     respond_to do |format|
       if @event.save
-        format.js { flash.now[:notice] = "Event was successfully created." }
-        format.html { redirect_to events_path }
+        format.js {}
+        format.html {}
+        redirect_to events_path, notice: "Event was successfully created."
       else
         format.js
       end


### PR DESCRIPTION
This change fixes a bug that pagination causes the redirect to fail when a new event is saved.
---

**Before submitting, check that:**

 - [ ] You have added (passing) tests for your code.
 - [x] You have written good* commit messages.
 - [ ] You have squashed relevant commits together.
 - [ ] You have ensured that RuboCop is passing.
 - [x] Your PR relates to one subject, with a clear title and
       description using complete, grammatically correct sentences.
---

*If you do not know what makes a good commit message, or why it
is important, please refer to these resources: [1][1], [2][2], [3][3].

[1]: https://robots.thoughtbot.com/5-useful-tips-for-a-better-commit-message
[2]: http://chris.beams.io/posts/git-commit/
[3]: https://github.com/blog/1943-how-to-write-the-perfect-pull-request


