### PR TITLE
Allow Users to see a donations' table on reports/index page

### DIFF
--- a/app/models/donation.rb
+++ b/app/models/donation.rb
@@ -1,6 +1,6 @@
 class Donation < ActiveRecord::Base
   self.per_page = 15
-  
+
   belongs_to :donor, inverse_of: :donations
   belongs_to :cause, inverse_of: :donations
   belongs_to :event, inverse_of: :donations

--- a/app/views/donors/index.html.slim
+++ b/app/views/donors/index.html.slim
@@ -18,14 +18,11 @@
                 .col-xs-6.col-sm-6.col-md-4
                   = select_tag :cause_id, options_from_collection_for_select(Cause.all, :id, :name, params[:cause_id]), prompt: "Filter by cause:", class: 'form-control', onchange: "cause_toggle(this.value)"
         tr
-          th 
-            | Name
+          th Name
             = sortable :name
-          th 
-            | NRIC/UEN
+          th NRIC/UEN
             = sortable :identification
-          th
-            | Total Donations
+          th Total Donations
             = sortable :total_donations
           th
       tbody

--- a/app/views/events/_index.html.slim
+++ b/app/views/events/_index.html.slim
@@ -16,14 +16,11 @@
                     span.input-group-btn
                       = submit_tag "Search", name: :nil, class: "btn btn-secondary"
         tr.thead-default
-          th
-            | Name
+          th Name
             = sortable :name
-          th
-            | Date
+          th Date
             = sortable :start_on
-          th
-            | Total Donations
+          th Total Donations
             = sortable :total_donations
           th
       tbody.events-index

--- a/app/views/events/show.html.slim
+++ b/app/views/events/show.html.slim
@@ -23,14 +23,11 @@
                     span.input-group-btn
                       = submit_tag "Search", name: :nil, class: "btn btn-secondary"
         tr
-          th 
-            | Name
+          th Name
             = sortable :donor_name
-          th 
-            | Date
+          th Date
             = sortable :created_at
-          th 
-            | Donation
+          th Donation
             = sortable :amount
           th
       tbody
@@ -42,7 +39,7 @@
             td = donation.donor.name
             td = l donation.created_at.to_date
             td $#{number_with_delimiter(donation.amount.round, delimiter: ",")}
-            td 
+            td
               = link_to edit_donation_path(donation), remote: true do
                 i.fa.fa-pencil.fa-lg
 

--- a/app/views/reports/_report_chart.html.slim
+++ b/app/views/reports/_report_chart.html.slim
@@ -10,6 +10,8 @@
 
 
 .row.margin-top
+  .col-xs-12.text-xs-center
+      h5 Total Donations: $#{report.donations.sum(:amount).round}
   - if !report.cause_id.empty? || !report.event_id.empty?
     = area_chart report.donations.group_by_week("donations.created_at").sum(:amount)
   - else

--- a/app/views/reports/_report_table.html.slim
+++ b/app/views/reports/_report_table.html.slim
@@ -1,0 +1,20 @@
+.table-responsive.margin-top
+  table.table
+    thead.thead-default
+      tr
+        th Name
+        th NRIC/UEN
+        th Date
+        th Cause
+        th Amount
+    tbody
+      tr
+        - if report.donations.blank? && params[:search].present?
+          h4 There is no donor matching <em>#{params[:search]}</em>.
+      - report.donations.each do |donation|
+        tr
+          td = donation.donor.name
+          td = link_to donation.donor.identification, donor_path(donation.donor)
+          td = l donation.created_at.to_date
+          td = donation.cause.name
+          td $#{number_with_delimiter(donation.amount.round, delimiter: ",")}

--- a/app/views/reports/index.html.slim
+++ b/app/views/reports/index.html.slim
@@ -25,3 +25,4 @@
 
 - if @report.present?
   = render "report_chart", report: @report
+  = render "report_table", report: @report


### PR DESCRIPTION
This change adds a table of donations on `reports/index` page that show donations for a report.

![screencapture-localhost-3000-donations-reports-1479788888138](https://cloud.githubusercontent.com/assets/19661205/20510962/29bc70a2-b0af-11e6-9348-e1dcd4450bf2.png)

---

**Before submitting, check that:**

 - [ ] You have added (passing) tests for your code.
 - [x] You have written good* commit messages.
 - [x] You have squashed relevant commits together.
 - [x] You have ensured that RuboCop is passing.
 - [x] Your PR relates to one subject, with a clear title and
       description using complete, grammatically correct sentences.

---

If your change contains views, ensure that:

 - [x] You have included a screenshot of the new view.

---

*If you do not know what makes a good commit message, or why it
is important, please refer to these resources: [1][1], [2][2], [3][3].

[1]: https://robots.thoughtbot.com/5-useful-tips-for-a-better-commit-message
[2]: http://chris.beams.io/posts/git-commit/
[3]: https://github.com/blog/1943-how-to-write-the-perfect-pull-request


Add “Total Donations” field to reports