### PR TITLE
Allow Users to see who created/updated a Donor or Donation

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -19,4 +19,14 @@ module ApplicationHelper
       end
     link_to "", safe_params(sort: column.to_s, direction: direction), class: css_class
   end
+
+  def whodunnit(object)
+    if object.versions.last&.event == "update"
+      "Last updated on #{l object.versions.last.created_at.localtime} by #{User.where('id = ?', object.versions.last.whodunnit).first.email}"
+    elsif object.versions.last&.event == "create"
+      "Created on #{l object.created_at.localtime} by #{User.where('id = ?', object.versions.last&.whodunnit).first.email}"
+    else
+      "Created on #{l object.created_at.localtime}"
+    end
+  end
 end

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -8,14 +8,4 @@ module EventsHelper
       "#{l event.start_on, format: :short} - #{l event.end_on, format: :default}"
     end
   end
-
-  def event_whodunnit(event)
-    if event.versions.last&.event == "update"
-      "Last updated on #{l event.versions.last.created_at.localtime} by #{User.where('id = ?', event.versions.last.whodunnit).first.email}"
-    elsif event.versions.last&.event == "create"
-      "Created on #{l event.created_at.localtime} by #{User.where('id = ?', event.versions.last&.whodunnit).first.email}"
-    else
-      "Created on #{l event.created_at.localtime}"
-    end
-  end
 end

--- a/app/models/donation.rb
+++ b/app/models/donation.rb
@@ -1,4 +1,5 @@
 class Donation < ActiveRecord::Base
+  has_paper_trail
   self.per_page = 15
 
   belongs_to :donor, inverse_of: :donations

--- a/app/views/donations/_edit.html.slim
+++ b/app/views/donations/_edit.html.slim
@@ -6,6 +6,8 @@
       h5 Edit Donation Details
       = form_for(@donation, remote: true) do |f|
         .form-group
+          p.metadata = whodunnit(@donation)
+        .form-group
           = f.label :created_at, "Donated On", class: "control-label"
           = f.text_field :created_at, class: "form-control datepicker", value: l(@donation.created_at.to_date)
         = render "form", f: f

--- a/app/views/donors/show.html.slim
+++ b/app/views/donors/show.html.slim
@@ -8,10 +8,15 @@
 #show_partial
   = render "show"
 
-div
-  h2 Total Amount Donated
-  h1 $#{number_with_delimiter(@donor.total_donations(params[:cause_id]), delimiter: ",")}
-  h5 Donor since #{@donor.created_at.strftime("%d %b %Y")} (#{time_ago_in_words(@donor.created_at)})
+h6 Donor since #{@donor.created_at.strftime("%d %b %Y")} (#{time_ago_in_words(@donor.created_at)})
+p.metadata = whodunnit(@donor)
+.card.card-inverse.card-info.text-xs-center
+  .card-block
+    h1 Total amount donated
+    h1 $#{number_with_delimiter(@donor.total_donations(params[:cause_id]), delimiter: ",")}
+
+
+
 .table-responsive
   table.table
     thead.thead-default

--- a/app/views/events/show.html.slim
+++ b/app/views/events/show.html.slim
@@ -3,7 +3,7 @@
   .col-xs-12
     h1 = @event.name
     p = event_dates(@event)
-    p.metadata = event_whodunnit(@event)
+    p.metadata = whodunnit(@event)
 
 .card.card-inverse.card-info.text-xs-center
   .card-block


### PR DESCRIPTION
This change allows Users to see who and when created/update Donor on `donors/show` page and also who and when created/updated a Donation in `donations/edit` modal.

See the screenshots below:

---

![screencapture-localhost-3000-donors-4-1479800075912](https://cloud.githubusercontent.com/assets/19661205/20515721/f3f49a52-b0cd-11e6-958a-e4e4bab91a2d.png)


![screencapture-localhost-3000-donors-4-1479800086240](https://cloud.githubusercontent.com/assets/19661205/20515662/82d48850-b0cd-11e6-9f7a-fcc29b9cd8ef.png)

**Before submitting, check that:**

 - [ ] You have added (passing) tests for your code.
 - [x] You have written good* commit messages.
 - [ ] You have squashed relevant commits together.
 - [x] You have ensured that RuboCop is passing.
 - [x] Your PR relates to one subject, with a clear title and
       description using complete, grammatically correct sentences.

---

If your change contains views, ensure that:

 - [x] You have included a screenshot of the new view.

---

*If you do not know what makes a good commit message, or why it
is important, please refer to these resources: [1][1], [2][2], [3][3].

[1]: https://robots.thoughtbot.com/5-useful-tips-for-a-better-commit-message
[2]: http://chris.beams.io/posts/git-commit/
[3]: https://github.com/blog/1943-how-to-write-the-perfect-pull-request

