### PR TITLE
[Fix #94] Allow Users to see a month's name on reports/index after a report is generated.

### DIFF
--- a/app/views/reports/_report_chart.html.slim
+++ b/app/views/reports/_report_chart.html.slim
@@ -1,8 +1,8 @@
 .row.col-xs-12.col-md-10.offset-md-1.text-xs-center
   .col-xs-6.col-md-3
-    <b>Year:</b> #{report.year}
+    <b>Year:</b> #{report.year.presence || "All"}
   .col-xs-6.col-md-3
-    <b>Month:</b> #{report.month.presence || "All" }
+    <b>Month:</b> #{Date::MONTHNAMES[report.month.to_i].presence || "All" }
   .col-xs-6.col-md-3
     <b>Cause:</b> #{report.cause&.name || "All"}
   .col-xs-6.col-md-3


### PR DESCRIPTION
This change allows users to see a month's name instead of a number on `reports/index` after a report is generated.

See the screenshot below:

---

![screen shot 2016-11-26 at 1 39 40 pm](https://cloud.githubusercontent.com/assets/19661205/20638288/e8ae7fd8-b3dd-11e6-97d6-e31bf9e61c8a.png)

**Before submitting, check that:**

 - [ ] You have added (passing) tests for your code.
 - [x] You have written good* commit messages.
 - [x] You have squashed relevant commits together.
 - [x] You have ensured that RuboCop is passing.
 - [x] Your PR relates to one subject, with a clear title and
       description using complete, grammatically correct sentences.

---

If your change contains views, ensure that:

 - [x] You have included a screenshot of the new view.

---

*If you do not know what makes a good commit message, or why it
is important, please refer to these resources: [1][1], [2][2], [3][3].

[1]: https://robots.thoughtbot.com/5-useful-tips-for-a-better-commit-message
[2]: http://chris.beams.io/posts/git-commit/
[3]: https://github.com/blog/1943-how-to-write-the-perfect-pull-request


