### PR TITLE
Fix #find_by_normalized_email

### DIFF
--- a/app/controllers/clearance/passwords_controller.rb
+++ b/app/controllers/clearance/passwords_controller.rb
@@ -90,7 +90,7 @@ class Clearance::PasswordsController < Clearance::BaseController
 
   def find_user_for_create
     Clearance.configuration.user_model
-             .find_by_normalized_email: params[:password][:email]
+             .find_by_normalized_email(params[:password][:email])
   end
 
   def find_user_for_edit


### PR DESCRIPTION
This change fixes the syntax of #find_by_normalized_email in `PasswordsController`.

---

**Before submitting, check that:**

 - [ ] You have added (passing) tests for your code.
 - [x] You have written good* commit messages.
 - [x] You have squashed relevant commits together.
 - [x] You have ensured that RuboCop is passing.
 - [x] Your PR relates to one subject, with a clear title and
       description using complete, grammatically correct sentences.

---

*If you do not know what makes a good commit message, or why it
is important, please refer to these resources: [1][1], [2][2], [3][3].

[1]: https://robots.thoughtbot.com/5-useful-tips-for-a-better-commit-message
[2]: http://chris.beams.io/posts/git-commit/
[3]: https://github.com/blog/1943-how-to-write-the-perfect-pull-request


