### PR TITLE
[Fix #128] Fix alert after donation is updated

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,6 @@
 class ApplicationController < ActionController::Base
+  add_flash_types :warning, :error, :success
+
   include Clearance::Controller
 
   protect_from_forgery with: :exception

--- a/app/controllers/donations_controller.rb
+++ b/app/controllers/donations_controller.rb
@@ -30,7 +30,7 @@ class DonationsController < ApplicationController
       if @donation.update(donation_params)
         format.js {}
         format.html {}
-        redirect_to donor_path(@donation.donor), notice: "Donation was successfully updated."
+        redirect_to donor_path(@donation.donor), success: "Donation was successfully updated."
       else
         format.js
       end


### PR DESCRIPTION
This change fixes the bug that flash message after donation is updated is not green.

Before:
![image](https://cloud.githubusercontent.com/assets/16523290/20640168/2ae54cd6-b412-11e6-8844-078916784930.png)

After:
![image](https://cloud.githubusercontent.com/assets/16523290/20640167/272fb41e-b412-11e6-89bd-2aa890335f2c.png)

---

**Before submitting, check that:**

 - [ ] You have added (passing) tests for your code.
 - [ ] You have written good* commit messages.
 - [ ] You have squashed relevant commits together.
 - [ ] You have ensured that RuboCop is passing.
 - [ ] Your PR relates to one subject, with a clear title and
       description using complete, grammatically correct sentences.

---

If your change contains views, ensure that:

 - [ ] You have included a screenshot of the new view.

---

*If you do not know what makes a good commit message, or why it
is important, please refer to these resources: [1][1], [2][2], [3][3].

[1]: https://robots.thoughtbot.com/5-useful-tips-for-a-better-commit-message
[2]: http://chris.beams.io/posts/git-commit/
[3]: https://github.com/blog/1943-how-to-write-the-perfect-pull-request


