### PR TITLE
[Fix #129] Disable a month field initially in report's form

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -40,6 +40,7 @@ $(document).ready(function() {
   $('#report-year').change(function() {
     if (!$(this).val()) {
       $("#report-month").attr("disabled", "disabled");
+      $("#report-month").val("");
     } else {
       $("#report-month").removeAttr("disabled");
     }

--- a/app/views/reports/index.html.slim
+++ b/app/views/reports/index.html.slim
@@ -10,7 +10,7 @@
 
           .form-group.col-xs-6
             label.form-control-label for="month" Month:
-            = select_month(@report.present? ? @report.month.to_i : 0, {prompt: "All"}, {class: "form-control", id: "report-month"} )
+            = select_month(@report.present? ? @report.month.to_i : 0, {prompt: "All", disabled: true}, {class: "form-control", id: "report-month"} )
 
           .form-group.col-xs-6
             label.form-control-label for="cause" Cause:


### PR DESCRIPTION
This change disables a month field in a report's form on `reports/index` when the page is loaded.
Also in the scenario when a year number is chosen, a month is chosen and then a year is switched back to "All" again, the month field is switched to "All" and is disabled.

See the screenshots below:

---

![screencapture-localhost-3000-donations-reports-1480220304325](https://cloud.githubusercontent.com/assets/19661205/20645526/ff2786f6-b49b-11e6-86de-28e861b60a4a.png)


**Before submitting, check that:**

 - [ ] You have added (passing) tests for your code.
 - [x] You have written good* commit messages.
 - [x] You have squashed relevant commits together.
 - [x] You have ensured that RuboCop is passing.
 - [x] Your PR relates to one subject, with a clear title and
       description using complete, grammatically correct sentences.

---

If your change contains views, ensure that:

 - [x] You have included a screenshot of the new view.

---

*If you do not know what makes a good commit message, or why it
is important, please refer to these resources: [1][1], [2][2], [3][3].

[1]: https://robots.thoughtbot.com/5-useful-tips-for-a-better-commit-message
[2]: http://chris.beams.io/posts/git-commit/
[3]: https://github.com/blog/1943-how-to-write-the-perfect-pull-request


Also show month as “All” if a year is changed from an actual year to
“All”