### PR TITLE
Allow only admins to add and delete users

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,5 @@
 class ApplicationController < ActionController::Base
-  add_flash_types :warning, :error, :success
+  add_flash_types :warning, :danger, :success
 
   include Clearance::Controller
 

--- a/app/controllers/clearance/users_controller.rb
+++ b/app/controllers/clearance/users_controller.rb
@@ -8,7 +8,7 @@ class Clearance::UsersController < Clearance::BaseController
       if @user.save
         format.js {}
         format.html {}
-        redirect_to :back, notice: "User was successfully created."
+        redirect_to :back, success: "User was successfully created."
       else
         format.js
       end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,29 @@
 class UsersController < Clearance::UsersController
+  before_action :require_admin_privileges, only: [:destroy, :index]
+
   def show
     @user = current_user
+  end
+
+  def index
+    @users = User.all.order(created_at: :desc).paginate(page: params[:page], per_page: 15)
+  end
+
+  def destroy
+    user = User.find(params[:id])
+    if user.admin?
+      redirect_to users_path
+      flash[:danger] = "Cannot delete admin user."
+    else
+      user.destroy
+      redirect_to users_path
+      flash[:success] = "User successfully deleted."
+    end
+  end
+
+  private
+
+  def require_admin_privileges
+    redirect_to root_path unless current_user.admin?
   end
 end

--- a/app/views/layouts/_navbar.html.slim
+++ b/app/views/layouts/_navbar.html.slim
@@ -6,6 +6,7 @@
       li.nav-item = link_to "Donors", donors_path, class: "nav-link"
       li.nav-item = link_to "Events", events_path, class: "nav-link"
       li.nav-item = link_to "Reports", reports_path, class: "nav-link"
+      li.nav-item = link_to "Users", users_path, class: "nav-link" if current_user.admin?
       .float-sm-right
         li.nav-item
           button.btn.btn-primary type="button" data-toggle="modal" data-target="#donationModal"

--- a/app/views/users/index.html.slim
+++ b/app/views/users/index.html.slim
@@ -1,0 +1,34 @@
+- flash.each do |key, value|
+    div class=("alert alert-#{key}") = value
+
+= render "users/new"
+.row
+  .col-xs-12.col-sm-4
+    h1 Users
+  .col-xs-12.col-sm-4.offset-sm-4
+    button.btn.btn-primary.pull-right type="button" data-toggle="modal" data-target="#userModal"
+      i.fa.fa-plus aria-hidden="true"
+      |  Add New User
+                
+.table-responsive
+  = form_tag users_path, method: :get do
+    table.table
+      thead.thead-default
+        tr
+          td colspan="3"
+        tr
+          th User
+          th Created on
+          th 
+      tbody
+        - @users.each do |user|
+          tr
+            td = user.email
+            td = l user.created_at.to_date, format: user.created_at.year == Date.today.year ? :short : :default
+            td
+              = link_to user, method: :delete, data:{ confirm: "Delete this user?"} do
+                i.fa.fa-trash.fa-lg
+ 
+.text-xs-center
+  .row
+    = will_paginate @users

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -4,8 +4,3 @@
 
 h3 Hi #{current_user.email}
  
-h4 
-= render "users/new"
-button.btn.btn-primary type="button" data-toggle="modal" data-target="#userModal"
-  i.fa.fa-plus aria-hidden="true"
-  |  Add new user

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
   end
   resources :donors, only: [:index, :show, :update, :edit]
   resources :events, only: [:create, :index, :show, :update, :edit]
-  resources :users, only: [:create, :show]
+  resources :users, only: [:create, :index, :show, :destroy]
 
   resource :passwords do
     member do

--- a/db/migrate/20161128144810_add_admin_to_users.rb
+++ b/db/migrate/20161128144810_add_admin_to_users.rb
@@ -1,0 +1,5 @@
+class AddAdminToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :admin, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161116012055) do
+ActiveRecord::Schema.define(version: 20161128144810) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -67,6 +67,7 @@ ActiveRecord::Schema.define(version: 20161116012055) do
     t.string   "encrypted_password", limit: 128, null: false
     t.string   "confirmation_token", limit: 128
     t.string   "remember_token",     limit: 128, null: false
+    t.boolean  "admin"
   end
 
   add_index "users", ["email"], name: "index_users_on_email", using: :btree

--- a/db/seeds/users.rb
+++ b/db/seeds/users.rb
@@ -3,5 +3,6 @@ puts "Seeding Users ..."
 unless User.any?
   User.create!(
    email: "dawn@highpoint.com",
-   password: "123456")
+   password: "123456",
+   admin: true)
 end


### PR DESCRIPTION
This change creates a users/index page that only admin users are able to access. On the users/index page, admin users are able to add a new user or delete existing users.

Note: An admin column has been added to the users table. Run `rake db:migrate` to migrate. The seed file is also updated so that `dawn@highpoint.com` is an admin.

Screenshot:
![image](https://cloud.githubusercontent.com/assets/16523290/20677678/d8d6e878-b5ce-11e6-926e-1aa69b4e03ad.png)


---

**Before submitting, check that:**

 - [ ] You have added (passing) tests for your code.
 - [x] You have written good* commit messages.
 - [ ] You have squashed relevant commits together.
 - [x] You have ensured that RuboCop is passing.
 - [x] Your PR relates to one subject, with a clear title and
       description using complete, grammatically correct sentences.

---

If your change contains models, ensure that:

 - [ ] You have included an updated screen shot of the ERD.
 - [ ] You have added database seeds for the model.
 - [ ] You have added working factories for the model.
 - [ ] Your validations have corresponding database constraints.

---

If your change contains views, ensure that:

 - [x] You have included a screenshot of the new view.

---

*If you do not know what makes a good commit message, or why it
is important, please refer to these resources: [1][1], [2][2], [3][3].

[1]: https://robots.thoughtbot.com/5-useful-tips-for-a-better-commit-message
[2]: http://chris.beams.io/posts/git-commit/
[3]: https://github.com/blog/1943-how-to-write-the-perfect-pull-request

