### PR TITLE
Let a User check 'Anonymous' option when creating a donation

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -30,6 +30,16 @@ $(document).on('turbolinks:load', function() {
     autoclose: true,
     todayHighlight: true
   });
+
+  $("input#anonymous").click(function() {
+    if ($("#donation_donor_identification").val() === "") {
+      $("#donation_donor_identification").val("Anonymous");
+      $("#donation_donor_identification").attr("readonly", "true");
+    } else {
+      $("#donation_donor_identification").val("");
+      $("#donation_donor_identification").removeAttr("readonly");
+    }
+  });
 });
 
 $(document).ready(function() {

--- a/app/views/donations/_new.html.slim
+++ b/app/views/donations/_new.html.slim
@@ -9,5 +9,9 @@
           = f.fields_for :donor, @modal_donation.donor do |donor|
             .form-group
               label.form-control-label for="donorDocs" Donor NRIC/UEN
-              = donor.text_field :identification, class: "form-control", placeholder: "Enter 'Anonymous' if unknown"
-          = render "donations/form", f: f
+              = donor.text_field :identification, class: "form-control", placeholder: "Click 'Anonymous' if unknown"
+            .form-check
+              = check_box_tag "Anonymous", true, false, class: "checkbox", id: "anonymous"
+              = label_tag :anonymous, "Anonymous", class: "form-check-label"
+
+            = render "donations/form", f: f


### PR DESCRIPTION
This change add an "Anonymous" checkbox to a `donations/new` form. When clicked, it pre populates a `Donor`s identification field with "Anonymous". 

See the screenshots below:

---

![screencapture-localhost-3000-donors-1480397648818](https://cloud.githubusercontent.com/assets/19661205/20697973/92ac23d0-b638-11e6-9ac6-ee0b7196bdb4.png)

**Before submitting, check that:**

 - [ ] You have added (passing) tests for your code.
 - [x] You have written good* commit messages.
 - [x] You have squashed relevant commits together.
 - [x] You have ensured that RuboCop is passing.
 - [x] Your PR relates to one subject, with a clear title and
       description using complete, grammatically correct sentences.

---


If your change contains views, ensure that:

 - [x] You have included a screenshot of the new view.

---

*If you do not know what makes a good commit message, or why it
is important, please refer to these resources: [1][1], [2][2], [3][3].

[1]: https://robots.thoughtbot.com/5-useful-tips-for-a-better-commit-message
[2]: http://chris.beams.io/posts/git-commit/
[3]: https://github.com/blog/1943-how-to-write-the-perfect-pull-request


