### PR TITLE
Allow Users to export `donors/index` table data in .csv

### DIFF
--- a/app/controllers/donors_controller.rb
+++ b/app/controllers/donors_controller.rb
@@ -7,6 +7,11 @@ class DonorsController < ApplicationController
   # GET /donors
   def index
     @donors = DonorsFinder.new(params).find_all.paginate(page: params[:page], per_page: 15)
+
+    respond_to do |format|
+      format.html
+      format.csv { send_data @donors.to_csv, filename: "donors-#{l Date.today, format: :filename}.csv" }
+    end
   end
 
   def update

--- a/app/models/donor.rb
+++ b/app/models/donor.rb
@@ -18,4 +18,13 @@ class Donor < ActiveRecord::Base
       donations.sum(:amount).round
     end
   end
+
+  def self.to_csv
+    CSV.generate(headers: true) do |csv|
+      csv << column_names
+      all.each do |donor|
+        csv << donor.attributes.values_at(*column_names)
+      end
+    end
+  end
 end

--- a/app/views/donors/index.html.slim
+++ b/app/views/donors/index.html.slim
@@ -10,18 +10,19 @@
           td colspan="3"
             .container-fluid
               .row
-                .col-xs-12.col-md-6.col-lg-8
+                .col-xs-12.col-md-5.col-lg-6
                   .input-group
                     = text_field_tag :search, params[:search], placeholder: "Search by donor name or NRIC/UEN ...", class: "form-control"
                     span.input-group-btn
                       = submit_tag "Search", name: :nil, class: "btn btn-secondary"
-                .col-xs-12.col-md-6.col-lg-4.margin-sm-top
+                .col-xs-12.col-md-5.col-lg-4.margin-sm-top
                   = select_tag :cause_id, options_from_collection_for_select(Cause.all, :id, :name, params[:cause_id]), prompt: "Filter by cause:", class: 'form-control', onchange: "cause_toggle(this.value)"
+                .col-xs-12.col-md-2.col-lg-2.margin-sm-top
+                  = link_to "Export", request.params.merge(format: "csv"), class: "btn btn-success"
         tr
           th Name #{sortable :name}
           th NRIC/UEN #{sortable :identification}
           th Total Donations #{sortable :total_donations}
-          th
       tbody
         tr
           - if @donors.blank? && params[:search].present?

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,5 +1,6 @@
 require File.expand_path("../boot", __FILE__)
 
+require "csv"
 require "rails"
 # Pick the frameworks you want:
 require "active_model/railtie"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -24,6 +24,7 @@ en:
     formats:
       default: "%d %b, %Y"
       short: "%d %b"
+      filename: "%d-%b-%Y"
   time:
     formats:
       default: "%d %b, %Y at %I:%M%p"


### PR DESCRIPTION
This change adds an "Export" button to `donors/index`, by pressing which a User can download a .csv file with the data from the table.

See the screenshots below:

---

![screencapture-localhost-3000-donors-1480391338349](https://cloud.githubusercontent.com/assets/19661205/20695853/1fcc5a46-b62a-11e6-9537-b6538bdd69f0.png)

![screen shot 2016-11-29 at 11 51 16 am](https://cloud.githubusercontent.com/assets/19661205/20695866/30080ba8-b62a-11e6-97b1-15fef2172fc6.png)


**Before submitting, check that:**

 - [ ] You have added (passing) tests for your code.
 - [x] You have written good* commit messages.
 - [x] You have squashed relevant commits together.
 - [x] You have ensured that RuboCop is passing.
 - [x] Your PR relates to one subject, with a clear title and
       description using complete, grammatically correct sentences.

---

If your change contains views, ensure that:

 - [x] You have included a screenshot of the new view.

---

*If you do not know what makes a good commit message, or why it
is important, please refer to these resources: [1][1], [2][2], [3][3].

[1]: https://robots.thoughtbot.com/5-useful-tips-for-a-better-commit-message
[2]: http://chris.beams.io/posts/git-commit/
[3]: https://github.com/blog/1943-how-to-write-the-perfect-pull-request


