### PR TITLE
[Fix #95] Change default ordering of events index

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -36,8 +36,9 @@ class EventsController < ApplicationController
 
     respond_to do |format|
       if @event.update(event_params)
-        format.html { redirect_to events_path }
-        format.js { flash.now[:notice] = "Event was successfully updated." }
+        format.js {}
+        format.html {}
+        redirect_to events_path, notice: "Event was successfully updated." 
       else
         format.js
       end

--- a/app/finders/events_finder.rb
+++ b/app/finders/events_finder.rb
@@ -1,6 +1,6 @@
 class EventsFinder
   def initialize(params)
-    @sort_column = params[:sort] || "start_on"
+    @sort_column = params[:sort] || "updated_at"
     @sort_direction = params[:direction] || "DESC"
     @keyword = params[:search]
     @result = Event.unscoped


### PR DESCRIPTION
This change changes the default ordering of events index from `start_on` to `updated_at` so that when an event is newly created or updated, it will appear at the top of the index.

It also fixes a current error that the modal does not close when an event is updated.

---

**Before submitting, check that:**

 - [ ] You have added (passing) tests for your code.
 - [x] You have written good* commit messages.
 - [x] You have squashed relevant commits together.
 - [x] You have ensured that RuboCop is passing.
 - [x] Your PR relates to one subject, with a clear title and
       description using complete, grammatically correct sentences.

---

*If you do not know what makes a good commit message, or why it
is important, please refer to these resources: [1][1], [2][2], [3][3].

[1]: https://robots.thoughtbot.com/5-useful-tips-for-a-better-commit-message
[2]: http://chris.beams.io/posts/git-commit/
[3]: https://github.com/blog/1943-how-to-write-the-perfect-pull-request


