### PR TITLE
Allow user to see and reset search term

### DIFF
--- a/app/controllers/donors_controller.rb
+++ b/app/controllers/donors_controller.rb
@@ -8,6 +8,7 @@ class DonorsController < ApplicationController
   # GET /donors
   def index
     @donors = DonorsFinder.new(params).find_all.paginate(page: params[:page], per_page: 15)
+    @search = params[:search] || nil
 
     respond_to do |format|
       format.html

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -18,6 +18,7 @@ class EventsController < ApplicationController
 
   def index
     @events = EventsFinder.new(params).find_all.paginate(page: params[:page], per_page: 15)
+    @search = params[:search] || nil
     respond_to do |format|
       format.html
       format.js
@@ -27,6 +28,7 @@ class EventsController < ApplicationController
   def show
     @event = find_event(params[:id])
     @donations = DonationsFinder.new(params, @event).find_all.paginate(page: params[:page], per_page: 15)
+    @search = params[:search] || nil
   end
 
   # PATCH /update
@@ -38,7 +40,7 @@ class EventsController < ApplicationController
       if @event.update(event_params)
         format.js {}
         format.html {}
-        redirect_to events_path, notice: "Event was successfully updated." 
+        redirect_to events_path, notice: "Event was successfully updated."
       else
         format.js
       end

--- a/app/models/donor.rb
+++ b/app/models/donor.rb
@@ -3,6 +3,8 @@ class Donor < ActiveRecord::Base
 
   self.per_page = 15
 
+  before_create :set_name
+
   default_scope { order(created_at: :desc) }
 
   has_many :donations, inverse_of: :donor
@@ -26,5 +28,9 @@ class Donor < ActiveRecord::Base
         csv << donor.attributes.values_at(*column_names)
       end
     end
+  end
+
+  def set_name
+    self.name = "" if name.blank?
   end
 end

--- a/app/views/donors/index.html.slim
+++ b/app/views/donors/index.html.slim
@@ -12,13 +12,20 @@
               .row
                 .col-xs-12.col-md-5.col-lg-6
                   .input-group
-                    = text_field_tag :search, params[:search], placeholder: "Search by donor name or NRIC/UEN ...", class: "form-control"
+                    = text_field_tag :search, nil, placeholder: "Search by donor name or NRIC/UEN ...", class: "form-control"
                     span.input-group-btn
                       = submit_tag "Search", name: :nil, class: "btn btn-secondary"
                 .col-xs-12.col-md-5.col-lg-4.margin-sm-top
                   = select_tag :cause_id, options_from_collection_for_select(Cause.all, :id, :name, params[:cause_id]), prompt: "Filter by cause:", class: 'form-control', onchange: "cause_toggle(this.value)"
                 .col-xs-12.col-md-2.col-lg-2.margin-sm-top
                   = link_to "Export", request.params.merge(format: "csv"), class: "btn btn-success"
+              .row
+                .col-xs-12.col-md-6.col-lg-8
+                  h1
+                  -if @search.present?
+                    button.btn.btn-sm.btn-primary type="submit" name= "search" value= nil
+                      | #{@search}
+                      i.fa.fa-close aria-hidden="true"
         tr
           th Name #{sortable :name}
           th NRIC/UEN #{sortable :identification}

--- a/app/views/events/_index.html.slim
+++ b/app/views/events/_index.html.slim
@@ -12,9 +12,16 @@
               .row
                 .col-xs-12.col-md-6.offset-md-6
                   .input-group
-                    = text_field_tag :search, params[:search], placeholder: "Search by event name ...", class: "form-control"
+                    = text_field_tag :search, nil, placeholder: "Search by event name ...", class: "form-control"
                     span.input-group-btn
                       = submit_tag "Search", name: :nil, class: "btn btn-secondary"
+                div.col-xs-12.col-md-6.offset-md-6
+                  h1
+                  -if @search.present?
+                    button.btn.btn-sm.btn-primary type="submit" name= "search" value= nil
+                      | #{@search}
+                      i.fa.fa-close aria-hidden="true"
+
         tr.thead-default
           th Name #{sortable :name}
           th Date #{sortable :start_on}

--- a/app/views/events/show.html.slim
+++ b/app/views/events/show.html.slim
@@ -25,9 +25,16 @@
                   .row
                     .col-xs-12.col-md-6.offset-md-6
                       div.input-group
-                        = text_field_tag :search, params[:search], placeholder: "Search by donor name ...", class: "form-control"
+                        = text_field_tag :search, nil, placeholder: "Search by donor name ...", class: "form-control"
                         span.input-group-btn
                           = submit_tag "Search", name: :nil, class: "btn btn-secondary"
+
+                    .col-xs-12.col-md-6.offset-md-6
+                      h1
+                      -if @search.present?
+                        button.btn.btn-sm.btn-primary type="submit" name= "search" value= nil
+                          | #{@search}
+                          i.fa.fa-close aria-hidden="true"
             tr
               th Name #{sortable :donor_name}
               th Date #{sortable :created_at}


### PR DESCRIPTION
This change allows a user to see and reset the search term on the donors/index, events/index and events/show pages.

It also sets a donor's name to `""` on creation, to avoid nil results not showing up when the search value is `nil`.

See screenshots below.

Donors/index:
![image](https://cloud.githubusercontent.com/assets/16523290/20841650/8d7ea5ea-b8ef-11e6-930d-366e4ef6ceae.png)

Events/index:
![image](https://cloud.githubusercontent.com/assets/16523290/20841672/9ea25e48-b8ef-11e6-9285-d48b9f0ed50e.png)

Events/show:
![image](https://cloud.githubusercontent.com/assets/16523290/20841672/9ea25e48-b8ef-11e6-9285-d48b9f0ed50e.png)

---

**Before submitting, check that:**

 - [ ] You have added (passing) tests for your code.
 - [x] You have written good* commit messages.
 - [ ] You have squashed relevant commits together.
 - [x] You have ensured that RuboCop is passing.
 - [x] Your PR relates to one subject, with a clear title and
       description using complete, grammatically correct sentences.

---

If your change contains views, ensure that:

 - [x] You have included a screenshot of the new view.

---

*If you do not know what makes a good commit message, or why it
is important, please refer to these resources: [1][1], [2][2], [3][3].

[1]: https://robots.thoughtbot.com/5-useful-tips-for-a-better-commit-message
[2]: http://chris.beams.io/posts/git-commit/
[3]: https://github.com/blog/1943-how-to-write-the-perfect-pull-request

