### PR TITLE
Allow Users to see which Donors share the same postal code

### DIFF
--- a/app/models/donor.rb
+++ b/app/models/donor.rb
@@ -11,7 +11,7 @@ class Donor < ActiveRecord::Base
 
   scope :search, ->(keyword) { where("name ILIKE :keyword OR identification ILIKE :keyword", keyword: "%#{keyword}%") }
 
-  scope :same_postcode, ->(postcode) { where("postal_code ILIKE ?", postcode) }
+  scope :same_postcode, ->(postcode) { where(postal_code: postcode) }
 
   def total_donations(cause_id = nil)
     if cause_id.present?

--- a/app/models/donor.rb
+++ b/app/models/donor.rb
@@ -11,6 +11,8 @@ class Donor < ActiveRecord::Base
 
   scope :search, ->(keyword) { where("name ILIKE :keyword OR identification ILIKE :keyword", keyword: "%#{keyword}%") }
 
+  scope :same_postcode, ->(postcode) { where("postal_code ILIKE ?", postcode) }
+
   def total_donations(cause_id = nil)
     if cause_id.present?
       donations.where(cause_id: cause_id).sum(:amount).round

--- a/app/views/donors/_show.html.slim
+++ b/app/views/donors/_show.html.slim
@@ -17,6 +17,16 @@
 
           .col-xs-6.col-md-6
             p <b>Address:</b> #{@donor.address} #{@donor.postal_code}
+            - if !@donor.postal_code&.empty? && Donor.same_postcode(@donor.postal_code).count > 1
+              p
+                | Shares postal code with
+                - Donor.same_postcode(@donor.postal_code).each do |d|
+                  - if d.name == @donor.name
+                    break
+                  - elsif Donor.same_postcode(@donor.postal_code).count > 2
+                    = link_to " #{d.name} |", donor_path(d)
+                  - else
+                    = link_to " #{d.name}", donor_path(d)
             p.comments = @donor.comments
 
         .row

--- a/spec/factories/donors.rb
+++ b/spec/factories/donors.rb
@@ -8,6 +8,8 @@ FactoryGirl.define do
 
     name "Test"
 
+    postal_code "111222"
+
     trait :invalid do
       identification nil
     end

--- a/spec/models/donor_spec.rb
+++ b/spec/models/donor_spec.rb
@@ -35,6 +35,6 @@ RSpec.describe Donor, type: :model do
       @donor3 = create(:donor, postal_code: "333444")
     end
 
-    it { expect(described_class.same_postcode("111222")).to match_array [@donor_1, @donor_2] }
+    it { expect(described_class.same_postcode("111222")).to match_array [@donor1, @donor2] }
   end
 end

--- a/spec/models/donor_spec.rb
+++ b/spec/models/donor_spec.rb
@@ -27,4 +27,14 @@ RSpec.describe Donor, type: :model do
     it { expect(described_class.search("smith")).to contain_exactly(@match_beginning, @match_middle, @match_end) }
     it { expect(described_class.search("b777")).to contain_exactly(@match_identification) }
   end
+
+  describe ".same_postcode" do
+    before do
+      @donor1 = create(:donor)
+      @donor2 = create(:donor)
+      @donor3 = create(:donor, postal_code: "333444")
+    end
+
+    it { expect(described_class.same_postcode("111222")).to match_array [@donor_1, @donor_2] }
+  end
 end


### PR DESCRIPTION
This change adds "Shares address with" information on `donors/show` page.

See the screenshots below:

---

when sharing a postal code with ONE donor:
![screencapture-localhost-3000-donors-3-1481878713298](https://cloud.githubusercontent.com/assets/19661205/21257266/233c0060-c3b2-11e6-985d-c52a580624d9.png)
when sharing a postal code with MULTIPLE donors:
![screencapture-localhost-3000-donors-2-1481878676098](https://cloud.githubusercontent.com/assets/19661205/21257268/26d28b0e-c3b2-11e6-92c7-8b2e33c5730c.png)


**Before submitting, check that:**

 - [x] You have added (passing) tests for your code.
 - [x] You have written good* commit messages.
 - [x] You have squashed relevant commits together.
 - [x] You have ensured that RuboCop is passing.
 - [x] Your PR relates to one subject, with a clear title and
       description using complete, grammatically correct sentences.

---

If your change contains views, ensure that:

 - [x] You have included a screenshot of the new view.

---

*If you do not know what makes a good commit message, or why it
is important, please refer to these resources: [1][1], [2][2], [3][3].

[1]: https://robots.thoughtbot.com/5-useful-tips-for-a-better-commit-message
[2]: http://chris.beams.io/posts/git-commit/
[3]: https://github.com/blog/1943-how-to-write-the-perfect-pull-request


