### PR TITLE
[FIx #144] Show User in navbar which page is currently open

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -29,4 +29,8 @@ module ApplicationHelper
       "Created on #{l object.created_at.localtime}"
     end
   end
+
+  def active_class(link_path)
+    current_page?(link_path) ? "active" : ""
+  end
 end

--- a/app/views/layouts/_navbar.html.slim
+++ b/app/views/layouts/_navbar.html.slim
@@ -3,10 +3,10 @@
   .collapse.navbar-toggleable-xs#navbarResponsive
     = link_to "HCSA Admin", donations_path, class: "navbar-brand"
     ul.nav.navbar-nav
-      li.nav-item = link_to "Donors", donors_path, class: "nav-link"
-      li.nav-item = link_to "Events", events_path, class: "nav-link"
-      li.nav-item = link_to "Reports", reports_path, class: "nav-link"
-      li.nav-item = link_to "Users", users_path, class: "nav-link" if current_user.admin?
+      li.nav-item class=active_class(donors_path) = link_to "Donors", donors_path, class: "nav-link"
+      li.nav-item class=active_class(events_path) = link_to "Events", events_path, class: "nav-link"
+      li.nav-item class=active_class(reports_path) = link_to "Reports", reports_path, class: "nav-link"
+      li.nav-item class=active_class(users_path) = link_to "Users", users_path, class: "nav-link" if current_user.admin?
       .float-sm-right
         li.nav-item
           button.btn.btn-primary type="button" data-toggle="modal" data-target="#donationModal"


### PR DESCRIPTION
This change allows users to see which page is currently opened by changing the color of the link in the `navbar` accordingly.

See the screenshot below:

---

![screen shot 2017-01-15 at 12 05 53 am](https://cloud.githubusercontent.com/assets/19661205/21956207/ae308e3c-dab6-11e6-8a0e-9eb35b22aec2.png)


**Before submitting, check that:**

 - [ ] You have added (passing) tests for your code.
 - [x] You have written good* commit messages.
 - [x] You have squashed relevant commits together.
 - [x] You have ensured that RuboCop is passing.
 - [x] Your PR relates to one subject, with a clear title and
       description using complete, grammatically correct sentences.

---

If your change contains views, ensure that:

 - [x] You have included a screenshot of the new view.

---

*If you do not know what makes a good commit message, or why it
is important, please refer to these resources: [1][1], [2][2], [3][3].

[1]: https://robots.thoughtbot.com/5-useful-tips-for-a-better-commit-message
[2]: http://chris.beams.io/posts/git-commit/
[3]: https://github.com/blog/1943-how-to-write-the-perfect-pull-request

