### PR TITLE
Don't allow Users edit Anonymous donor's information

### DIFF
--- a/app/models/donor.rb
+++ b/app/models/donor.rb
@@ -36,11 +36,15 @@ class Donor < ActiveRecord::Base
     self.name = "" if name.blank?
   end
 
+  def anonymous?
+    self.name == "Anonymous"
+  end
+
   def shares_postal_code_with_others?
-    true if self.postal_code&.present? && Donor.same_postcode(self.postal_code).count > 1
+    self.postal_code&.present? && Donor.same_postcode(self.postal_code).count > 1
   end
 
   def donors_own_postal_code(donor)
-    true if donor.name == self.name
+    donor.name == self.name
   end
 end

--- a/app/views/donors/_anonymous.html.slim
+++ b/app/views/donors/_anonymous.html.slim
@@ -1,0 +1,7 @@
+.col-xs-12
+  .card
+    .card-block
+      .card-text
+        .row
+          .col-xs-12.text-xs-center
+            h2 #{@donor.name}

--- a/app/views/donors/show.html.slim
+++ b/app/views/donors/show.html.slim
@@ -3,9 +3,12 @@
 .row
   #edit_partial
 
-- if @new_donation == "true"
+- if @new_donation == "true" && !@donor.anonymous?
   .row
     = render "edit"
+- elsif @donor.anonymous?
+  .row
+    = render "anonymous"
 - else
   .row
     #show_partial


### PR DESCRIPTION
This change removes all unnecessary information about Anonymous donor and renders `donors/anonymous` when new anonymous donation is created.

![screencapture-localhost-3000-donors-1-1484553728105](https://cloud.githubusercontent.com/assets/19661205/21975012/2e51a1c4-dc05-11e6-9657-086595642165.png)


---

**Before submitting, check that:**

 - [ ] You have added (passing) tests for your code.
 - [x] You have written good* commit messages.
 - [x] You have squashed relevant commits together.
 - [x] You have ensured that RuboCop is passing.
 - [x] Your PR relates to one subject, with a clear title and
       description using complete, grammatically correct sentences.

---

If your change contains views, ensure that:

 - [x] You have included a screenshot of the new view.

---

*If you do not know what makes a good commit message, or why it
is important, please refer to these resources: [1][1], [2][2], [3][3].

[1]: https://robots.thoughtbot.com/5-useful-tips-for-a-better-commit-message
[2]: http://chris.beams.io/posts/git-commit/
[3]: https://github.com/blog/1943-how-to-write-the-perfect-pull-request

