### PR TITLE
Change submit button's text in donations/new modal to "Create Donation"

### DIFF
--- a/app/views/donations/_edit.html.slim
+++ b/app/views/donations/_edit.html.slim
@@ -11,3 +11,6 @@
           = f.label :created_at, "Donated On", class: "control-label"
           = f.text_field :created_at, class: "form-control datepicker", value: l(@donation.created_at.to_date)
         = render "form", f: f
+        .actions
+          = f.submit "Save Changes", class: "btn btn-primary form-control"
+

--- a/app/views/donations/_form.html.slim
+++ b/app/views/donations/_form.html.slim
@@ -11,6 +11,3 @@
 .form-group
   label.form-control-label for="causeOrEvent" Event:
   = f.select :event_id, Event.pluck(:name, :id), { include_blank: true }, class:"form-control"
-
-.actions
-  = f.submit "Save changes", class: "btn btn-primary form-control"

--- a/app/views/donations/_new.html.slim
+++ b/app/views/donations/_new.html.slim
@@ -15,3 +15,6 @@
               = label_tag :anonymous, "Anonymous", class: "form-check-label"
 
             = render "donations/form", f: f
+            .actions
+              = f.submit "Create Donation", class: "btn btn-primary form-control"
+


### PR DESCRIPTION
This change sets submit button's text in `donations/new` modal to "Create Donation" instead of "Save changes".

See the screenshot below

---

![screen shot 2017-01-16 at 4 09 19 pm](https://cloud.githubusercontent.com/assets/19661205/21975183/2e1a75d6-dc06-11e6-9286-80c18df497fe.png)


**Before submitting, check that:**

 - [ ] You have added (passing) tests for your code.
 - [x] You have written good* commit messages.
 - [x] You have squashed relevant commits together.
 - [x] You have ensured that RuboCop is passing.
 - [x] Your PR relates to one subject, with a clear title and
       description using complete, grammatically correct sentences.

---

If your change contains views, ensure that:

 - [x] You have included a screenshot of the new view.

---

*If you do not know what makes a good commit message, or why it
is important, please refer to these resources: [1][1], [2][2], [3][3].

[1]: https://robots.thoughtbot.com/5-useful-tips-for-a-better-commit-message
[2]: http://chris.beams.io/posts/git-commit/
[3]: https://github.com/blog/1943-how-to-write-the-perfect-pull-request

