### PR TITLE
Allow Users to see which donors share the same postal code only if the donor's postal codes are present

### DIFF
--- a/app/models/donor.rb
+++ b/app/models/donor.rb
@@ -39,4 +39,8 @@ class Donor < ActiveRecord::Base
   def shares_postal_code_with_others?
     true if self.postal_code&.present? && Donor.same_postcode(self.postal_code).count > 1
   end
+
+  def donors_own_postal_code(donor)
+    true if donor.name == self.name
+  end
 end

--- a/app/models/donor.rb
+++ b/app/models/donor.rb
@@ -35,4 +35,8 @@ class Donor < ActiveRecord::Base
   def set_name
     self.name = "" if name.blank?
   end
+
+  def shares_postal_code_with_others?
+    true if self.postal_code&.present? && Donor.same_postcode(self.postal_code).count > 1
+  end
 end

--- a/app/views/donors/_show.html.slim
+++ b/app/views/donors/_show.html.slim
@@ -21,7 +21,7 @@
               p
                 | Shares postal code with
                 - Donor.same_postcode(@donor.postal_code).each do |d|
-                  - if d.name == @donor.name
+                  - if @donor.donors_own_postal_code(d)
                     break
                   - elsif Donor.same_postcode(@donor.postal_code).count > 2
                     = link_to " #{d.name} |", donor_path(d)

--- a/app/views/donors/_show.html.slim
+++ b/app/views/donors/_show.html.slim
@@ -17,7 +17,7 @@
 
           .col-xs-6.col-md-6
             p <b>Address:</b> #{@donor.address} #{@donor.postal_code}
-            - if @donor.postal_code&.present? && Donor.same_postcode(@donor.postal_code).count > 1
+            - if @donor.shares_postal_code_with_others?
               p
                 | Shares postal code with
                 - Donor.same_postcode(@donor.postal_code).each do |d|

--- a/app/views/donors/_show.html.slim
+++ b/app/views/donors/_show.html.slim
@@ -17,7 +17,7 @@
 
           .col-xs-6.col-md-6
             p <b>Address:</b> #{@donor.address} #{@donor.postal_code}
-            - if !@donor.postal_code&.empty? && Donor.same_postcode(@donor.postal_code).count > 1
+            - if @donor.postal_code&.present? && Donor.same_postcode(@donor.postal_code).count > 1
               p
                 | Shares postal code with
                 - Donor.same_postcode(@donor.postal_code).each do |d|


### PR DESCRIPTION
This change removes from the equation not only empty postal codes but also the ones that are `nil`.

---

**Before submitting, check that:**

 - [ ] You have added (passing) tests for your code.
 - [x] You have written good* commit messages.
 - [x] You have squashed relevant commits together.
 - [x] You have ensured that RuboCop is passing.
 - [x] Your PR relates to one subject, with a clear title and
       description using complete, grammatically correct sentences.

---

*If you do not know what makes a good commit message, or why it
is important, please refer to these resources: [1][1], [2][2], [3][3].

[1]: https://robots.thoughtbot.com/5-useful-tips-for-a-better-commit-message
[2]: http://chris.beams.io/posts/git-commit/
[3]: https://github.com/blog/1943-how-to-write-the-perfect-pull-request

